### PR TITLE
clippy vs bindgen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+#[allow(deref_nullptr)]
 pub mod bindings;
 
 mod _macros; // Starts w/_ to be sorted at front by rustfmt!

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -775,7 +775,7 @@ mod test {
     #[test]
     fn test_edge_index_access() {
         let tables = make_small_table_collection();
-        assert_eq!(tables.is_indexed(), true);
+        assert!(tables.is_indexed());
         assert_eq!(
             tables.edge_insertion_order().unwrap().len(),
             tables.edges().num_rows() as usize


### PR DESCRIPTION
- Add #[allow(deref_nullptr)] so that rust-lang/rust-bindgen#1651 doesn't cause CI failures via clippy.
- Change assert to make clippy happy.
