### PR TITLE
fix doc link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ pub mod provenance;
 
 /// A provenance ID
 ///
-/// This is an integer referring to a row of an [``ProvenanceTable``].
+/// This is an integer referring to a row of a [``provenance::ProvenanceTable``].
 ///
 /// The features for this type follow the same pattern as for [``NodeId``]
 #[cfg(any(doc, feature = "provenance"))]


### PR DESCRIPTION
- clippy vs bindgen (#130)
- * Establish a pattern for stronger ID types (#129)
- NodeTable::metadata now uses Into<NodeId>. (#134)
- Add IndividualId. (#133)
- Add PopulationId (#135)
- Add SiteId and MutationId (#136)
- Add MigrationId and ProvenanceId (#137)
- Add EdgeId (#138)
- strong id type cleanup (#139)
- fix link from ProvenanceId to ProvenanceTable in docs
