### PR TITLE
Improve tests for table types

### DIFF
--- a/src/individual_table.rs
+++ b/src/individual_table.rs
@@ -67,6 +67,26 @@ pub type IndividualTableRefIterator<'a> =
     crate::table_iterator::TableIterator<&'a IndividualTable<'a>>;
 pub type IndividualTableIterator<'a> = crate::table_iterator::TableIterator<IndividualTable<'a>>;
 
+impl<'a> Iterator for IndividualTableRefIterator<'a> {
+    type Item = IndividualTableRow;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let rv = make_individual_table_row(self.table, self.pos);
+        self.pos += 1;
+        rv
+    }
+}
+
+impl<'a> Iterator for IndividualTableIterator<'a> {
+    type Item = IndividualTableRow;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let rv = make_individual_table_row(&self.table, self.pos);
+        self.pos += 1;
+        rv
+    }
+}
+
 impl<'a> IndividualTable<'a> {
     pub(crate) fn new_from_table(individuals: &'a ll_bindings::tsk_individual_table_t) -> Self {
         IndividualTable {

--- a/src/migration_table.rs
+++ b/src/migration_table.rs
@@ -112,7 +112,7 @@ impl<'a> MigrationTable<'a> {
     ///
     /// * [`TskitError::IndexError`] if `row` is out of range.
     pub fn node<M: Into<MigrationId> + Copy>(&'a self, row: M) -> Result<NodeId, TskitError> {
-        unsafe_tsk_column_access!(row.into().0, 0, self.num_rows(), self.table_.source, NodeId)
+        unsafe_tsk_column_access!(row.into().0, 0, self.num_rows(), self.table_.node, NodeId)
     }
 
     /// Return the source population for a given row.
@@ -128,7 +128,7 @@ impl<'a> MigrationTable<'a> {
             row.into().0,
             0,
             self.num_rows(),
-            self.table_.node,
+            self.table_.source,
             PopulationId
         )
     }

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -275,3 +275,48 @@ impl<'a> ProvenanceTable<'a> {
         crate::table_iterator::make_table_iterator::<&ProvenanceTable<'a>>(&self)
     }
 }
+
+#[cfg(test)]
+mod test_trigger_provenance_errors {
+    use super::*;
+    use crate::test_fixtures::make_empty_table_collection;
+    use Provenance;
+
+    #[test]
+    #[should_panic]
+    fn test_empty_record_string() {
+        //TODO: decide if we like this behavior:
+        //See GitHub issue 150 -- this behavior should change.
+        let mut tables = make_empty_table_collection(1.0);
+        let row_id = tables.add_provenance(&String::from("")).unwrap();
+        let _ = tables.provenances().row(row_id).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod test_provenance_tables {
+    use super::*;
+    use crate::test_fixtures::make_empty_table_collection;
+    use Provenance;
+
+    #[test]
+    fn test_add_rows() {
+        let records = vec!["banana".to_string(), "split".to_string()];
+        let mut tables = make_empty_table_collection(1.);
+        for (i, r) in records.iter().enumerate() {
+            let row_id = tables.add_provenance(&r).unwrap();
+            assert!(row_id == ProvenanceId(i as crate::tsk_id_t));
+            assert_eq!(tables.provenances().record(row_id).unwrap(), *r);
+        }
+        assert_eq!(tables.provenances().num_rows() as usize, records.len());
+        for (i, row) in tables.provenances_iter().enumerate() {
+            assert_eq!(records[i], row.record);
+        }
+        for (i, row) in tables.provenances().iter().enumerate() {
+            assert_eq!(records[i], row.record);
+        }
+
+        assert!(tables.provenances().row(0).unwrap() == tables.provenances().row(0).unwrap());
+        assert!(tables.provenances().row(0).unwrap() != tables.provenances().row(1).unwrap());
+    }
+}

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -2,6 +2,35 @@
 use crate::*;
 
 #[cfg(test)]
+pub fn make_empty_table_collection(L: f64) -> TableCollection {
+    TableCollection::new(L).unwrap()
+}
+
+#[cfg(test)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Eq, PartialEq, Copy, Clone)]
+pub struct GenericMetadata {
+    pub data: i64,
+}
+
+#[cfg(test)]
+impl Default for GenericMetadata {
+    fn default() -> Self {
+        Self { data: 42 }
+    }
+}
+
+#[cfg(test)]
+impl crate::metadata::MetadataRoundtrip for GenericMetadata {
+    fn encode(&self) -> Result<Vec<u8>, crate::metadata::MetadataError> {
+        handle_metadata_return!(bincode::serialize(&self))
+    }
+
+    fn decode(md: &[u8]) -> Result<Self, crate::metadata::MetadataError> {
+        handle_metadata_return!(bincode::deserialize(md))
+    }
+}
+
+#[cfg(test)]
 pub fn make_small_table_collection() -> TableCollection {
     let mut tables = TableCollection::new(1000.).unwrap();
     tables.add_node(0, 1.0, TSK_NULL, TSK_NULL).unwrap();


### PR DESCRIPTION
In light of the new row ID types introduced recently (see #128), this PR adds a lot of tests to the various "tables" files.
These tests have:

* Improved code coverage
* Improved test organization (I think/hope)
* Found and fixed some API issues
* Created redundancy with previous tests.

Removing/reducing redundant tests can be handled in a follow-up PR.  That follow up can maybe also add more of what we need, which is detailed checks of all the various Option inputs, etc., and how they affect table row equality comparisons, etc..