### PR TITLE
Add marker traits for table-specific metadata.

### DIFF
--- a/examples/mutation_metadata_bincode.rs
+++ b/examples/mutation_metadata_bincode.rs
@@ -27,6 +27,8 @@ impl metadata::MetadataRoundtrip for Mutation {
     }
 }
 
+impl metadata::MutationMetadata for Mutation {}
+
 pub fn run() {
     let mut tables = tskit::TableCollection::new(1000.).unwrap();
     // The simulation generates a mutation:
@@ -38,7 +40,7 @@ pub fn run() {
 
     // The mutation's data are included as metadata:
     tables
-        .add_mutation_with_metadata(0, 0, 0, 0.0, None, Some(&m))
+        .add_mutation_with_metadata(0, 0, 0, 0.0, None, &m)
         .unwrap();
 
     // Decoding requres 2 unwraps:

--- a/examples/mutation_metadata_std.rs
+++ b/examples/mutation_metadata_std.rs
@@ -18,7 +18,7 @@ pub fn run() {
 
     // The mutation's data are included as metadata:
     tables
-        .add_mutation_with_metadata(0, 0, 0, 0.0, None, Some(&m))
+        .add_mutation_with_metadata(0, 0, 0, 0.0, None, &m)
         .unwrap();
 
     // Decoding requres 2 unwraps:
@@ -62,6 +62,8 @@ impl metadata::MetadataRoundtrip for Mutation {
         })
     }
 }
+
+impl metadata::MutationMetadata for Mutation {}
 
 #[test]
 fn run_test() {

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -31,6 +31,27 @@ impl crate::metadata::MetadataRoundtrip for GenericMetadata {
 }
 
 #[cfg(test)]
+impl crate::metadata::MutationMetadata for GenericMetadata {}
+
+#[cfg(test)]
+impl crate::metadata::SiteMetadata for GenericMetadata {}
+
+#[cfg(test)]
+impl crate::metadata::EdgeMetadata for GenericMetadata {}
+
+#[cfg(test)]
+impl crate::metadata::NodeMetadata for GenericMetadata {}
+
+#[cfg(test)]
+impl crate::metadata::IndividualMetadata for GenericMetadata {}
+
+#[cfg(test)]
+impl crate::metadata::PopulationMetadata for GenericMetadata {}
+
+#[cfg(test)]
+impl crate::metadata::MigrationMetadata for GenericMetadata {}
+
+#[cfg(test)]
 pub fn make_small_table_collection() -> TableCollection {
     let mut tables = TableCollection::new(1000.).unwrap();
     tables
@@ -168,4 +189,7 @@ pub mod bad_metadata {
             handle_metadata_return!(bincode::deserialize(md))
         }
     }
+
+    impl crate::metadata::MutationMetadata for F {}
+    impl crate::metadata::MutationMetadata for Ff {}
 }


### PR DESCRIPTION
Currently, metadata is a single trait.  When one thinks of external tools exporting to tskit, one starts to worry that loads of `Vec<T: tskit::metadata::MetadataRoundTrip>` accumulate, leading to the possibility that the wrong metadata will be sent to the wrong table.

This PR is an attempt to add safety to the traits, meaning that a mutation table row can only get "mutation meta data", which client code must specify via a marker trait.

It seems that we can also provide little macros like `register_mutation_metadata!(...)` to streamline this a bit.