### PR TITLE
Add metadata registration macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,12 @@ chrono = {version = "0.4.19", optional = true}
 serde = {version = "1.0.118", features = ["derive"], optional = true}
 serde_json = {version = "1.0.67", optional = true}
 bincode = {version = "1.3.1", optional = true}
+tskit-derive = {version = "0.1.0", path = "tskit-derive", optional = true}
 
 [dev-dependencies]
 clap = "~2.33.3"
 serde = {version = "1.0.118", features = ["derive"]}
+serde-pickle = "0.6"
 bincode = "1.3.1"
 rand = "0.8.3"
 rand_distr = "0.4.0"
@@ -39,8 +41,7 @@ pkg-config = "0.3"
 
 [features]
 provenance = ["chrono"]
-serde_json_metadata = ["serde", "serde_json"]
-serde_bincode_metadata = ["serde", "bincode"]
+derive = ["tskit-derive", "serde", "serde_json", "bincode"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -322,66 +322,6 @@ macro_rules! handle_metadata_return {
     };
 }
 
-/// Implement [`crate::metadata::MetadataRoundtrip`]
-/// for a type using `serde_json`.
-///
-/// Requires the `serde_json_metadata` feature.
-#[cfg(any(doc, feature = "serde_json_metadata"))]
-#[macro_export]
-macro_rules! serde_json_metadata {
-    ($structname: ty) => {
-        impl $crate::metadata::MetadataRoundtrip for $structname {
-            fn encode(&self) -> Result<Vec<u8>, $crate::metadata::MetadataError> {
-                match serde_json::to_string(self) {
-                    Ok(x) => Ok(x.as_bytes().to_vec()),
-                    Err(e) => {
-                        Err($crate::metadata::MetadataError::RoundtripError { value: Box::new(e) })
-                    }
-                }
-            }
-
-            fn decode(md: &[u8]) -> Result<Self, $crate::metadata::MetadataError> {
-                let value: Result<Self, serde_json::Error> = serde_json::from_slice(md);
-                match value {
-                    Ok(v) => Ok(v),
-                    Err(e) => {
-                        Err($crate::metadata::MetadataError::RoundtripError { value: Box::new(e) })
-                    }
-                }
-            }
-        }
-    };
-}
-
-/// Implement [`crate::metadata::MetadataRoundtrip`]
-/// for a type using `bincode`.
-///
-/// Requires the `serde_bincode_metadata` feature.
-#[cfg(any(doc, feature = "serde_bincode_metadata"))]
-#[macro_export]
-macro_rules! serde_bincode_metadata {
-    ($structname: ty) => {
-        impl $crate::metadata::MetadataRoundtrip for $structname {
-            fn encode(&self) -> Result<Vec<u8>, tskit::metadata::MetadataError> {
-                match bincode::serialize(&self) {
-                    Ok(x) => Ok(x),
-                    Err(e) => {
-                        Err($crate::metadata::MetadataError::RoundtripError { value: Box::new(e) })
-                    }
-                }
-            }
-            fn decode(md: &[u8]) -> Result<Self, tskit::metadata::MetadataError> {
-                match bincode::deserialize(md) {
-                    Ok(x) => Ok(x),
-                    Err(e) => {
-                        Err($crate::metadata::MetadataError::RoundtripError { value: Box::new(e) })
-                    }
-                }
-            }
-        }
-    };
-}
-
 #[cfg(test)]
 mod test {
     use crate::error::TskitError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,11 +45,18 @@
 //!
 //! * `provenance`
 //!     * Enables [`provenance`]
-//! * `serde_json_metadata`
-//!     * Enables [`serde_json_metadata`] macro.
-//! * `serde_bincode_metadata`
-//!     * Enables [`serde_bincode_metadata`] macro.
+//! * `derive` enables the following derive macros:
+//!     * [`MutationMetadata`]
+//!     * [`IndividualMetadata`]
+//!     * [`SiteMetadata`]
+//!     * [`EdgeMetadata`]
+//!     * [`NodeMetadata`]
+//!     * [`MigrationMetadata`]
+//!     * [`PopulationMetadata`]
 //!
+//!     To see these derive macros in action, take a look
+//!     [`here`](metadata).
+//!         
 //! To add features to your `Cargo.toml` file:
 //!
 //! ```toml

--- a/tskit-derive/Cargo.toml
+++ b/tskit-derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tskit-derive"
+version = "0.1.0"
+edition = "2018"
+authors = ["tskit developers <admin@tskit.dev>"]
+description = "procedural macros for tskit-rust"
+license = "MIT"
+homepage = "https://github.com/tskit-dev/tskit-rust"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0", features = ["derive"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+proc-macro-error = "1.0.4"

--- a/tskit-derive/src/lib.rs
+++ b/tskit-derive/src/lib.rs
@@ -1,0 +1,105 @@
+use proc_macro::TokenStream;
+
+fn impl_serde_json_roundtrip(name: &syn::Ident) -> TokenStream {
+    let gen = quote::quote!(
+        impl ::tskit::metadata::MetadataRoundtrip for #name {
+            fn encode(&self) -> Result<Vec<u8>, ::tskit::metadata::MetadataError> {
+                match ::serde_json::to_string(self) {
+                    Ok(x) => Ok(x.as_bytes().to_vec()),
+                    Err(e) => {
+                        Err(::tskit::metadata::MetadataError::RoundtripError { value: Box::new(e) })
+                    }
+                }
+            }
+
+            fn decode(md: &[u8]) -> Result<Self, ::tskit::metadata::MetadataError> {
+                let value: Result<Self, ::serde_json::Error> = ::serde_json::from_slice(md);
+                match value {
+                    Ok(v) => Ok(v),
+                    Err(e) => {
+                        Err(::tskit::metadata::MetadataError::RoundtripError { value: Box::new(e) })
+                    }
+                }
+            }
+        }
+    );
+    gen.into()
+}
+
+fn impl_serde_bincode_roundtrip(name: &syn::Ident) -> TokenStream {
+    let gen = quote::quote!(
+        impl ::tskit::metadata::MetadataRoundtrip for #name {
+            fn encode(&self) -> Result<Vec<u8>, ::tskit::metadata::MetadataError> {
+                match ::bincode::serialize(&self) {
+                    Ok(x) => Ok(x),
+                    Err(e) => {
+                        Err(::tskit::metadata::MetadataError::RoundtripError { value: Box::new(e) })
+                    }
+                }
+            }
+            fn decode(md: &[u8]) -> Result<Self, ::tskit::metadata::MetadataError> {
+                match ::bincode::deserialize(md) {
+                    Ok(x) => Ok(x),
+                    Err(e) => {
+                        Err(::tskit::metadata::MetadataError::RoundtripError { value: Box::new(e) })
+                    }
+                }
+            }
+        }
+    );
+    gen.into()
+}
+
+fn impl_metadata_roundtrip_macro(ast: &syn::DeriveInput) -> Result<TokenStream, syn::Error> {
+    let name = &ast.ident;
+    let attrs = &ast.attrs;
+
+    for attr in attrs.iter() {
+        if attr.path.is_ident("serializer") {
+            let lit: syn::LitStr = attr.parse_args().unwrap();
+            let serializer = lit.value();
+
+            if &serializer == "serde_json" {
+                return Ok(impl_serde_json_roundtrip(name));
+            } else if &serializer == "bincode" {
+                return Ok(impl_serde_bincode_roundtrip(name));
+            } else {
+                proc_macro_error::abort!(serializer, "is not a supported protocol.");
+            }
+        } else {
+            proc_macro_error::abort!(attr.path, "is not a supported attribute.");
+        }
+    }
+
+    proc_macro_error::abort_call_site!("missing [serializer(...)] attribute")
+}
+
+macro_rules! make_derive_metadata_tag {
+    ($function: ident, $metadatatag: ident) => {
+        #[proc_macro_error::proc_macro_error]
+        #[proc_macro_derive($metadatatag, attributes(serializer))]
+        /// Register a type as metadata.
+        pub fn $function(input: TokenStream) -> TokenStream {
+            let ast: syn::DeriveInput = match syn::parse(input) {
+                Ok(ast) => ast,
+                Err(err) => proc_macro_error::abort!(err),
+            };
+            let mut roundtrip = impl_metadata_roundtrip_macro(&ast).unwrap();
+            let name = &ast.ident;
+            let gen: proc_macro::TokenStream = quote::quote!(
+                impl ::tskit::metadata::$metadatatag for #name {}
+            )
+            .into();
+            roundtrip.extend(gen);
+            roundtrip
+        }
+    };
+}
+
+make_derive_metadata_tag!(individual_metadata_derive, IndividualMetadata);
+make_derive_metadata_tag!(mutation_metadata_derive, MutationMetadata);
+make_derive_metadata_tag!(site_metadata_derive, SiteMetadata);
+make_derive_metadata_tag!(population_metadata_derive, PopulationMetadata);
+make_derive_metadata_tag!(node_metadata_derive, NodeMetadata);
+make_derive_metadata_tag!(edge_metadata_derive, EdgeMetadata);
+make_derive_metadata_tag!(migration_metadata_derive, MigrationMetadata);


### PR DESCRIPTION
- start on metadata registration macros
- add registration + rountrip tests for json
- test w/newtypes
- add remaining macros and tests
- restrict macro to feature set
