### PR TITLE
Replace chrono dependency with humantime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0"
 libc = "0.2.81"
 streaming-iterator = "0.1.5"
 bitflags = "1.2.1"
-chrono = {version = "0.4.19", optional = true}
+humantime = {version = "2.1.0", optional = true}
 serde = {version = "1.0.118", features = ["derive"], optional = true}
 serde_json = {version = "1.0.67", optional = true}
 bincode = {version = "1.3.1", optional = true}
@@ -29,10 +29,11 @@ tskit-derive = {version = "0.1.0", path = "tskit-derive", optional = true}
 [dev-dependencies]
 clap = "~2.33.3"
 serde = {version = "1.0.118", features = ["derive"]}
-serde-pickle = "0.6"
+serde-pickle = "1.1.0"
 bincode = "1.3.1"
 rand = "0.8.3"
 rand_distr = "0.4.0"
+chrono = "0.4.19"
 
 [build-dependencies]
 bindgen = "0.59.1"
@@ -40,7 +41,7 @@ cc = { version = "1.0", features = ["parallel"] }
 pkg-config = "0.3"
 
 [features]
-provenance = ["chrono"]
+provenance = ["humantime"]
 derive = ["tskit-derive", "serde", "serde_json", "bincode"]
 
 [package.metadata.docs.rs]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -113,14 +113,14 @@
 //! // risk a `panic!`.
 //! impl tskit::metadata::MetadataRoundtrip for Metadata {
 //!     fn encode(&self) -> Result<Vec<u8>, tskit::metadata::MetadataError> {
-//!         match serde_pickle::to_vec(self, true) {
+//!         match serde_pickle::to_vec(self, serde_pickle::SerOptions::default()) {
 //!             Ok(v) => Ok(v),
 //!             Err(e) => Err(tskit::metadata::MetadataError::RoundtripError{ value: Box::new(e) }),
 //!         }
 //!     }
 //!
 //!     fn decode(md: &[u8]) -> Result<Self, tskit::metadata::MetadataError> {
-//!         match serde_pickle::from_slice(md) {
+//!         match serde_pickle::from_slice(md, serde_pickle::DeOptions::default()) {
 //!             Ok(x) => Ok(x),
 //!             Err(e) => Err(tskit::metadata::MetadataError::RoundtripError{ value: Box::new(e) }),
 //!         }

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -729,7 +729,7 @@ impl crate::traits::NodeListGenerator for TableCollection {}
 #[cfg(any(doc, feature = "provenance"))]
 impl crate::provenance::Provenance for TableCollection {
     fn add_provenance(&mut self, record: &str) -> Result<crate::ProvenanceId, TskitError> {
-        let timestamp = chrono::prelude::Local::now().to_rfc3339();
+        let timestamp = humantime::format_rfc3339(std::time::SystemTime::now()).to_string();
         let rv = unsafe {
             ll_bindings::tsk_provenance_table_add_row(
                 &mut (*self.as_mut_ptr()).provenances,

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1141,7 +1141,7 @@ impl crate::traits::NodeListGenerator for TreeSequence {}
 #[cfg(any(doc, feature = "provenance"))]
 impl crate::provenance::Provenance for TreeSequence {
     fn add_provenance(&mut self, record: &str) -> Result<crate::ProvenanceId, TskitError> {
-        let timestamp = chrono::prelude::Local::now().to_rfc3339();
+        let timestamp = humantime::format_rfc3339(std::time::SystemTime::now()).to_string();
         let rv = unsafe {
             ll_bindings::tsk_provenance_table_add_row(
                 &mut (*self.inner.tables).provenances,


### PR DESCRIPTION
Avoids [RUSTSEC-2020-0071](https://rustsec.org/advisories/RUSTSEC-2020-0071) and [RUSTSEC-2020-0159](https://rustsec.org/advisories/RUSTSEC-2020-0159) vulnerabilities in crates using `tskit`