### PR TITLE
Update flags API.

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -498,6 +498,29 @@ macro_rules! impl_time_position_arithmetic {
     };
 }
 
+macro_rules! impl_from_for_flag_types {
+    ($flagstype: ty) => {
+        impl From<$crate::RawFlags> for $flagstype {
+            fn from(value: $crate::RawFlags) -> Self {
+                <$flagstype>::from_bits_truncate(value)
+            }
+        }
+    };
+}
+
+macro_rules! impl_flags {
+    ($flagstype: ty) => {
+        impl $flagstype {
+            /// We do not enforce valid flags in the library.
+            /// This function will return `true` if any bits
+            /// are set that do not correspond to allowed flags.
+            pub fn is_valid(&self) -> bool {
+                Self::from_bits(self.bits()).is_some()
+            }
+        }
+    };
+}
+
 /// Convenience macro to handle implementing
 /// [`crate::metadata::MetadataRoundtrip`]
 #[macro_export]

--- a/src/individual_table.rs
+++ b/src/individual_table.rs
@@ -1,13 +1,14 @@
 use crate::bindings as ll_bindings;
 use crate::metadata;
+use crate::IndividualFlags;
 use crate::IndividualId;
 use crate::Location;
-use crate::{tsk_flags_t, tsk_id_t, tsk_size_t, TskitError};
+use crate::{tsk_id_t, tsk_size_t, TskitError};
 
 /// Row of a [`IndividualTable`]
 pub struct IndividualTableRow {
     pub id: IndividualId,
-    pub flags: tsk_flags_t,
+    pub flags: IndividualFlags,
     pub location: Option<Vec<Location>>,
     pub parents: Option<Vec<IndividualId>>,
     pub metadata: Option<Vec<u8>>,
@@ -110,8 +111,14 @@ impl<'a> IndividualTable<'a> {
     /// # Errors
     ///
     /// * [`TskitError::IndexError`] if `row` is out of range.
-    pub fn flags<I: Into<IndividualId> + Copy>(&self, row: I) -> Result<tsk_flags_t, TskitError> {
-        unsafe_tsk_column_access!(row.into().0, 0, self.num_rows(), self.table_.flags)
+    pub fn flags<I: Into<IndividualId> + Copy>(
+        &self,
+        row: I,
+    ) -> Result<IndividualFlags, TskitError> {
+        match unsafe_tsk_column_access!(row.into().0, 0, self.num_rows(), self.table_.flags) {
+            Ok(f) => Ok(IndividualFlags::from(f)),
+            Err(e) => Err(e),
+        }
     }
 
     /// Return the locations for a given row.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,6 +449,9 @@ impl_id_traits!(ProvenanceId);
 /// the error message is stored for diplay.
 pub type TskReturnValue = Result<i32, TskitError>;
 
+/// Alias for tsk_flags_t
+pub type RawFlags = crate::bindings::tsk_flags_t;
+
 /// Version of the rust crate.
 ///
 /// To get the C API version, see:

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,6 @@ pub use streaming_iterator::DoubleEndedStreamingIterator;
 pub use streaming_iterator::StreamingIterator;
 pub use {
     crate::EdgeId, crate::IndividualId, crate::Location, crate::MigrationId, crate::MutationId,
-    crate::NodeId, crate::PopulationId, crate::Position, crate::SiteId, crate::SizeType,
-    crate::Time,
+    crate::NodeId, crate::PopulationId, crate::Position, crate::RawFlags, crate::SiteId,
+    crate::SizeType, crate::Time,
 };

--- a/src/test_simplification.rs
+++ b/src/test_simplification.rs
@@ -2,17 +2,17 @@
 mod tests {
     use crate::test_fixtures::make_small_table_collection_two_trees;
     use crate::test_fixtures::treeseq_from_small_table_collection_two_trees;
+    use crate::NodeFlags;
     use crate::NodeId;
     use crate::SimplificationOptions;
     use crate::TableAccess;
-    use crate::TSK_NODE_IS_SAMPLE;
 
     #[test]
     fn test_simplify_tables() {
         let mut tables = make_small_table_collection_two_trees();
         let mut samples: Vec<NodeId> = vec![];
         for (i, row) in tables.nodes_iter().enumerate() {
-            if row.flags & TSK_NODE_IS_SAMPLE > 0 {
+            if row.flags.contains(NodeFlags::IS_SAMPLE) {
                 samples.push((i as i32).into());
             }
         }

--- a/tests/example_flags.rs
+++ b/tests/example_flags.rs
@@ -1,0 +1,55 @@
+use tskit::{NodeFlags, RawFlags, SimplificationOptions};
+
+fn clip_invalid_flags() {
+    // This value contains bits set to 1
+    // that are not valid values for
+    // tskit::SimplificationFlags
+    let f: RawFlags = 1000000;
+
+    // Creating flags from this value will unset invalid
+    // bits, meaning the final value != the input value.
+    let simplification_flags = SimplificationOptions::from(f);
+
+    assert_ne!(f, simplification_flags.bits());
+    assert!(simplification_flags.is_valid());
+
+    // You can skip the unsetting of invalid bits...
+    let simplification_flags = unsafe { SimplificationOptions::from_bits_unchecked(f) };
+
+    // ... and use this function to check.
+    assert!(!simplification_flags.is_valid());
+}
+
+fn example_node_flags() {
+    let f: RawFlags = 1000000;
+
+    // Node flags allow user-specified values,
+    // so ::from accepts input as-is.
+    let mut node_flags = NodeFlags::from(f);
+
+    assert_eq!(node_flags.bits(), f);
+    assert!(node_flags.is_valid());
+
+    // The first bit is not set...
+    assert!(!node_flags.contains(NodeFlags::IS_SAMPLE));
+
+    // Set the first bit, making the flag indicate "sample"
+    node_flags.toggle(NodeFlags::IS_SAMPLE);
+    assert!(node_flags.is_valid());
+    assert_ne!(node_flags.bits(), f);
+
+    // Remove the sample status
+    node_flags.remove(NodeFlags::IS_SAMPLE);
+    assert!(node_flags.is_valid());
+    assert_eq!(node_flags.bits(), f);
+}
+
+#[test]
+fn test_clip_invalid_flags() {
+    clip_invalid_flags();
+}
+
+#[test]
+fn test_example_node_flags() {
+    example_node_flags();
+}


### PR DESCRIPTION
Implements several refinements to the handling of "flags":

* Add NodeFlags
* Add From<tsk_flags_t> for all flags type.
* The From is implemented by a macro for all flags types except NodeFlags.  From strips off disallowed bits if present.
* Add `impl` block for all flags types with a single fn, `validate`, that checks for invalid flags.

Breaking change:

Node and Individual flags replace tsk_flags_t in the public API, which changes the return value type of some fns.  In most cases, this will be transparent.