### PR TITLE
refactor: metadata_to_vector take ref to C table.

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -172,13 +172,13 @@ macro_rules! build_tskit_type {
 }
 
 macro_rules! metadata_to_vector {
-    ($self: expr, $row: expr) => {
+    ($table: expr, $row: expr) => {
         $crate::metadata::char_column_to_vector(
-            $self.table_.metadata,
-            $self.table_.metadata_offset,
+            $table.metadata,
+            $table.metadata_offset,
             $row,
-            $self.table_.num_rows,
-            $self.table_.metadata_length,
+            $table.num_rows,
+            $table.metadata_length,
         )
     };
 }

--- a/src/edge_table.rs
+++ b/src/edge_table.rs
@@ -31,13 +31,14 @@ fn make_edge_table_row(table: &EdgeTable, pos: tsk_id_t) -> Option<EdgeTableRow>
     // set up the iterator
     let p = crate::SizeType::try_from(pos).unwrap();
     if p < table.num_rows() {
+        let table_ref = table.table_;
         let rv = EdgeTableRow {
             id: pos.into(),
             left: table.left(pos).unwrap(),
             right: table.right(pos).unwrap(),
             parent: table.parent(pos).unwrap(),
             child: table.child(pos).unwrap(),
-            metadata: table_row_decode_metadata!(table, pos),
+            metadata: table_row_decode_metadata!(table_ref, pos),
         };
         Some(rv)
     } else {
@@ -137,7 +138,8 @@ impl<'a> EdgeTable<'a> {
         &'a self,
         row: EdgeId,
     ) -> Result<Option<T>, TskitError> {
-        let buffer = metadata_to_vector!(self, row.0)?;
+        let table_ref = self.table_;
+        let buffer = metadata_to_vector!(table_ref, row.0)?;
         decode_metadata_row!(T, buffer)
     }
 

--- a/src/individual_table.rs
+++ b/src/individual_table.rs
@@ -56,12 +56,13 @@ fn make_individual_table_row(table: &IndividualTable, pos: tsk_id_t) -> Option<I
     // set up the iterator
     let p = crate::SizeType::try_from(pos).unwrap();
     if p < table.num_rows() {
+        let table_ref = table.table_;
         let rv = IndividualTableRow {
             id: pos.into(),
             flags: table.flags(pos).unwrap(),
             location: table.location(pos).unwrap(),
             parents: table.parents(pos).unwrap(),
-            metadata: table_row_decode_metadata!(table, pos),
+            metadata: table_row_decode_metadata!(table_ref, pos),
         };
         Some(rv)
     } else {
@@ -245,7 +246,8 @@ impl<'a> IndividualTable<'a> {
         &'a self,
         row: IndividualId,
     ) -> Result<Option<T>, TskitError> {
-        let buffer = metadata_to_vector!(self, row.0)?;
+        let table_ref = self.table_;
+        let buffer = metadata_to_vector!(table_ref, row.0)?;
         decode_metadata_row!(T, buffer)
     }
 

--- a/src/migration_table.rs
+++ b/src/migration_table.rs
@@ -37,6 +37,7 @@ fn make_migration_table_row(table: &MigrationTable, pos: tsk_id_t) -> Option<Mig
     // set up the iterator
     let p = crate::SizeType::try_from(pos).unwrap();
     if p < table.num_rows() {
+        let table_ref = table.table_;
         Some(MigrationTableRow {
             id: pos.into(),
             left: table.left(pos).unwrap(),
@@ -45,7 +46,7 @@ fn make_migration_table_row(table: &MigrationTable, pos: tsk_id_t) -> Option<Mig
             source: table.source(pos).unwrap(),
             dest: table.dest(pos).unwrap(),
             time: table.time(pos).unwrap(),
-            metadata: table_row_decode_metadata!(table, pos),
+            metadata: table_row_decode_metadata!(table_ref, pos),
         })
     } else {
         None
@@ -183,7 +184,8 @@ impl<'a> MigrationTable<'a> {
         &'a self,
         row: MigrationId,
     ) -> Result<Option<T>, TskitError> {
-        let buffer = metadata_to_vector!(self, row.0)?;
+        let table_ref = self.table_;
+        let buffer = metadata_to_vector!(table_ref, row.0)?;
         decode_metadata_row!(T, buffer)
     }
 

--- a/src/mutation_table.rs
+++ b/src/mutation_table.rs
@@ -34,6 +34,7 @@ fn make_mutation_table_row(table: &MutationTable, pos: tsk_id_t) -> Option<Mutat
     // set up the iterator
     let p = crate::SizeType::try_from(pos).unwrap();
     if p < table.num_rows() {
+        let table_ref = table.table_;
         let rv = MutationTableRow {
             id: pos.into(),
             site: table.site(pos).unwrap(),
@@ -41,7 +42,7 @@ fn make_mutation_table_row(table: &MutationTable, pos: tsk_id_t) -> Option<Mutat
             parent: table.parent(pos).unwrap(),
             time: table.time(pos).unwrap(),
             derived_state: table.derived_state(pos).unwrap(),
-            metadata: table_row_decode_metadata!(table, pos),
+            metadata: table_row_decode_metadata!(table_ref, pos),
         };
         Some(rv)
     } else {
@@ -167,7 +168,8 @@ impl<'a> MutationTable<'a> {
         &'a self,
         row: MutationId,
     ) -> Result<Option<T>, TskitError> {
-        let buffer = metadata_to_vector!(self, row.0)?;
+        let table_ref = self.table_;
+        let buffer = metadata_to_vector!(table_ref, row.0)?;
         decode_metadata_row!(T, buffer)
     }
 

--- a/src/node_table.rs
+++ b/src/node_table.rs
@@ -33,13 +33,14 @@ fn make_node_table_row(table: &NodeTable, pos: tsk_id_t) -> Option<NodeTableRow>
     // set up the iterator
     let p = crate::SizeType::try_from(pos).unwrap();
     if p < table.num_rows() {
+        let table_ref = table.table_;
         Some(NodeTableRow {
             id: pos.into(),
             time: table.time(pos).unwrap(),
             flags: table.flags(pos).unwrap(),
             population: table.population(pos).unwrap(),
             individual: table.individual(pos).unwrap(),
-            metadata: table_row_decode_metadata!(table, pos),
+            metadata: table_row_decode_metadata!(table_ref, pos),
         })
     } else {
         None
@@ -186,7 +187,8 @@ impl<'a> NodeTable<'a> {
         &'a self,
         row: NodeId,
     ) -> Result<Option<T>, TskitError> {
-        let buffer = metadata_to_vector!(self, row.0)?;
+        let table_ref = self.table_;
+        let buffer = metadata_to_vector!(table_ref, row.0)?;
         decode_metadata_row!(T, buffer)
     }
 

--- a/src/population_table.rs
+++ b/src/population_table.rs
@@ -24,9 +24,10 @@ fn make_population_table_row(table: &PopulationTable, pos: tsk_id_t) -> Option<P
     // set up the iterator
     let p = crate::SizeType::try_from(pos).unwrap();
     if p < table.num_rows() {
+        let table_ref = table.table_;
         let rv = PopulationTableRow {
             id: pos.into(),
-            metadata: table_row_decode_metadata!(table, pos),
+            metadata: table_row_decode_metadata!(table_ref, pos),
         };
         Some(rv)
     } else {
@@ -82,7 +83,8 @@ impl<'a> PopulationTable<'a> {
         &'a self,
         row: PopulationId,
     ) -> Result<Option<T>, TskitError> {
-        let buffer = metadata_to_vector!(self, row.0)?;
+        let table_ref = self.table_;
+        let buffer = metadata_to_vector!(table_ref, row.0)?;
         decode_metadata_row!(T, buffer)
     }
 

--- a/src/site_table.rs
+++ b/src/site_table.rs
@@ -29,11 +29,12 @@ fn make_site_table_row(table: &SiteTable, pos: tsk_id_t) -> Option<SiteTableRow>
     // set up the iterator
     let p = crate::SizeType::try_from(pos).unwrap();
     if p < table.num_rows() {
+        let table_ref = table.table_;
         let rv = SiteTableRow {
             id: pos.into(),
             position: table.position(pos).unwrap(),
             ancestral_state: table.ancestral_state(pos).unwrap(),
-            metadata: table_row_decode_metadata!(table, pos),
+            metadata: table_row_decode_metadata!(table_ref, pos),
         };
         Some(rv)
     } else {
@@ -123,7 +124,8 @@ impl<'a> SiteTable<'a> {
         &'a self,
         row: SiteId,
     ) -> Result<Option<T>, TskitError> {
-        let buffer = metadata_to_vector!(self, row.0)?;
+        let table_ref = self.table_;
+        let buffer = metadata_to_vector!(table_ref, row.0)?;
         decode_metadata_row!(T, buffer)
     }
 


### PR DESCRIPTION
Rather than pass along references to rust-defined
tables, we now pass along refs to the underlying C
types.
