### PR TITLE
remove table struct lifetimes

### DIFF
--- a/src/node_table.rs
+++ b/src/node_table.rs
@@ -131,26 +131,6 @@ impl NodeTable {
         }
     }
 
-    /// Mutable access to node flags.
-    // pub fn flags_array_mut(&mut self) -> &mut [NodeFlags] {
-    //     unsafe {
-    //         std::slice::from_raw_parts_mut(
-    //             self.as_ll_ref().flags.cast::<NodeFlags>(),
-    //             usize::try_from(self.as_ll_ref().num_rows).unwrap(),
-    //         )
-    //     }
-    // }
-
-    /// Mutable access to node times.
-    // pub fn time_array_mut(&mut self) -> &mut [Time] {
-    //     unsafe {
-    //         std::slice::from_raw_parts_mut(
-    //             self.as_ll_ref().time.cast::<Time>(),
-    //             usize::try_from(self.as_ll_ref().num_rows).unwrap(),
-    //         )
-    //     }
-    // }
-
     /// Return the ``population`` value from row ``row`` of the table.
     ///
     /// # Errors

--- a/src/node_table.rs
+++ b/src/node_table.rs
@@ -132,24 +132,24 @@ impl NodeTable {
     }
 
     /// Mutable access to node flags.
-    pub fn flags_array_mut(&mut self) -> &mut [NodeFlags] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_ll_ref().flags.cast::<NodeFlags>(),
-                usize::try_from(self.as_ll_ref().num_rows).unwrap(),
-            )
-        }
-    }
+    // pub fn flags_array_mut(&mut self) -> &mut [NodeFlags] {
+    //     unsafe {
+    //         std::slice::from_raw_parts_mut(
+    //             self.as_ll_ref().flags.cast::<NodeFlags>(),
+    //             usize::try_from(self.as_ll_ref().num_rows).unwrap(),
+    //         )
+    //     }
+    // }
 
     /// Mutable access to node times.
-    pub fn time_array_mut(&mut self) -> &mut [Time] {
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_ll_ref().time.cast::<Time>(),
-                usize::try_from(self.as_ll_ref().num_rows).unwrap(),
-            )
-        }
-    }
+    // pub fn time_array_mut(&mut self) -> &mut [Time] {
+    //     unsafe {
+    //         std::slice::from_raw_parts_mut(
+    //             self.as_ll_ref().time.cast::<Time>(),
+    //             usize::try_from(self.as_ll_ref().num_rows).unwrap(),
+    //         )
+    //     }
+    // }
 
     /// Return the ``population`` value from row ``row`` of the table.
     ///

--- a/src/population_table.rs
+++ b/src/population_table.rs
@@ -74,8 +74,20 @@ impl PopulationTable {
         unsafe { &(*self.table_) }
     }
 
-    pub(crate) fn new_from_table(mutations: &ll_bindings::tsk_population_table_t) -> Self {
-        PopulationTable { table_: mutations }
+    pub(crate) fn new_from_table(populations: &ll_bindings::tsk_population_table_t) -> Self {
+        PopulationTable {
+            table_: populations,
+        }
+    }
+
+    pub(crate) fn new_null() -> Self {
+        Self {
+            table_: std::ptr::null(),
+        }
+    }
+
+    pub(crate) fn set_ptr(&mut self, ptr: *const ll_bindings::tsk_population_table_t) {
+        self.table_ = ptr;
     }
 
     /// Return the number of rows.

--- a/src/population_table.rs
+++ b/src/population_table.rs
@@ -87,6 +87,7 @@ impl PopulationTable {
     }
 
     pub(crate) fn set_ptr(&mut self, ptr: *const ll_bindings::tsk_population_table_t) {
+        assert!(!ptr.is_null());
         self.table_ = ptr;
     }
 

--- a/src/population_table.rs
+++ b/src/population_table.rs
@@ -70,6 +70,7 @@ pub struct PopulationTable {
 
 impl PopulationTable {
     fn as_ll_ref(&self) -> &ll_bindings::tsk_population_table_t {
+        // SAFETY: cannot be constructed with null pointer
         unsafe { &(*self.table_) }
     }
 
@@ -86,6 +87,7 @@ impl PopulationTable {
         &self,
         row: PopulationId,
     ) -> Result<Option<T>, TskitError> {
+        // SAFETY: cannot be constructed with null pointer
         let table_ref = unsafe { *self.table_ };
         let buffer = metadata_to_vector!(table_ref, row.0)?;
         decode_metadata_row!(T, buffer)

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -215,6 +215,11 @@ mod test_provenances {
             .tree_sequence(crate::TreeSequenceFlags::default())
             .unwrap();
         assert_eq!(ts.provenances().num_rows(), 1);
+        assert_eq!(row_id, 0);
+        let _ = ts.provenances().timestamp(row_id).unwrap();
+        // let _ = ts.provenances().record(row_id).unwrap();
+        // let _ = ts.provenances().row(row_id).unwrap();
+        assert_eq!(ts.provenances().num_rows(), 1);
         let row_id = ts.add_provenance(&s).unwrap();
         assert_eq!(row_id, 1);
         assert_eq!(ts.provenances().num_rows(), 2);

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -214,6 +214,7 @@ mod test_provenances {
             .unwrap();
         let row_id = ts.add_provenance(&s).unwrap();
         assert_eq!(row_id, 1);
+        assert_eq!(ts.provenances().num_rows(), 2);
         let _ = ts.provenances().timestamp(row_id).unwrap();
         let _ = ts.provenances().record(row_id).unwrap();
         let _ = ts.provenances().row(row_id).unwrap();

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -208,6 +208,7 @@ mod test_provenances {
         let row_id = tables.add_provenance(&s).unwrap();
         let _ = tables.provenances().row(row_id).unwrap();
         assert_eq!(tables.provenances().num_rows(), 1);
+        let _ = tables.provenances().row(row_id).unwrap();
 
         // and for tree sequences...
         tables.build_index().unwrap();

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -130,14 +130,13 @@ impl ProvenanceTable {
     ///
     /// [`TskitError::IndexError`] if `r` is out of range.
     pub fn timestamp<P: Into<ProvenanceId> + Copy>(&self, row: P) -> Result<String, TskitError> {
-        let ptr = unsafe { *self.table_ };
         match unsafe_tsk_ragged_char_column_access!(
             row.into().0,
             0,
             self.num_rows(),
-            ptr.timestamp,
-            ptr.timestamp_offset,
-            ptr.timestamp_length
+            self.as_ll_ref().timestamp,
+            self.as_ll_ref().timestamp_offset,
+            self.as_ll_ref().timestamp_length
         ) {
             Ok(Some(string)) => Ok(string),
             Ok(None) => Err(crate::TskitError::ValueError {
@@ -154,14 +153,13 @@ impl ProvenanceTable {
     ///
     /// [`TskitError::IndexError`] if `r` is out of range.
     pub fn record<P: Into<ProvenanceId> + Copy>(&self, row: P) -> Result<String, TskitError> {
-        let ptr = unsafe { *self.table_ };
         match unsafe_tsk_ragged_char_column_access!(
             row.into().0,
             0,
             self.num_rows(),
-            ptr.record,
-            ptr.record_offset,
-            ptr.record_length
+            self.as_ll_ref().record,
+            self.as_ll_ref().record_offset,
+            self.as_ll_ref().record_length
         ) {
             Ok(Some(string)) => Ok(string),
             Ok(None) => Ok(String::from("")),
@@ -215,6 +213,9 @@ mod test_provenances {
             .tree_sequence(crate::TreeSequenceFlags::default())
             .unwrap();
         let row_id = ts.add_provenance(&s).unwrap();
+        assert_eq!(row_id, 1);
+        let _ = ts.provenances().timestamp(row_id).unwrap();
+        let _ = ts.provenances().record(row_id).unwrap();
         let _ = ts.provenances().row(row_id).unwrap();
     }
 

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -121,7 +121,7 @@ impl ProvenanceTable {
 
     /// Return the number of rows
     pub fn num_rows(&self) -> SizeType {
-        println!("{}", unsafe { *self.table_ }.num_rows);
+        println!("check = {}", unsafe { *self.table_ }.num_rows);
         self.as_ll_ref().num_rows.into()
     }
 

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -121,7 +121,6 @@ impl ProvenanceTable {
 
     /// Return the number of rows
     pub fn num_rows(&self) -> SizeType {
-        println!("check = {}", unsafe { *self.table_ }.num_rows);
         self.as_ll_ref().num_rows.into()
     }
 

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -215,6 +215,7 @@ mod test_provenances {
         let mut ts = tables
             .tree_sequence(crate::TreeSequenceFlags::default())
             .unwrap();
+        assert_eq!(ts.provenances().num_rows(), 1);
         let row_id = ts.add_provenance(&s).unwrap();
         assert_eq!(row_id, 1);
         assert_eq!(ts.provenances().num_rows(), 2);

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -115,12 +115,13 @@ impl ProvenanceTable {
     }
 
     pub(crate) fn set_ptr(&mut self, ptr: *const ll_bindings::tsk_provenance_table_t) {
+        assert!(!ptr.is_null());
         self.table_ = ptr;
-        assert!(!self.table_.is_null());
     }
 
     /// Return the number of rows
     pub fn num_rows(&self) -> SizeType {
+        println!("{}", unsafe{*self.table_}.num_rows);
         self.as_ll_ref().num_rows.into()
     }
 
@@ -206,6 +207,7 @@ mod test_provenances {
         let s = String::from("");
         let row_id = tables.add_provenance(&s).unwrap();
         let _ = tables.provenances().row(row_id).unwrap();
+        assert_eq!(tables.provenances().num_rows(), 1);
 
         // and for tree sequences...
         tables.build_index().unwrap();

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -121,7 +121,7 @@ impl ProvenanceTable {
 
     /// Return the number of rows
     pub fn num_rows(&self) -> SizeType {
-        println!("{}", unsafe{*self.table_}.num_rows);
+        println!("{}", unsafe { *self.table_ }.num_rows);
         self.as_ll_ref().num_rows.into()
     }
 

--- a/src/site_table.rs
+++ b/src/site_table.rs
@@ -84,6 +84,17 @@ impl SiteTable {
         SiteTable { table_: sites }
     }
 
+    pub(crate) fn new_null() -> Self {
+        Self {
+            table_: std::ptr::null(),
+        }
+    }
+
+    pub(crate) fn set_ptr(&mut self, ptr: *const ll_bindings::tsk_site_table_t) {
+        assert!(!ptr.is_null());
+        self.table_ = ptr;
+    }
+
     /// Return the number of rows
     pub fn num_rows(&self) -> SizeType {
         self.as_ll_ref().num_rows.into()

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -79,6 +79,7 @@ pub struct TableCollection {
     edges: EdgeTable,
     migrations: MigrationTable,
     individuals: IndividualTable,
+    mutations: MutationTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -100,6 +101,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
         let edges = EdgeTable::new_null();
         let migrations = MigrationTable::new_null();
         let individuals = IndividualTable::new_null();
+        let mutations = MutationTable::new_null();
 
         #[cfg(not(feature = "provenance"))]
         {
@@ -110,6 +112,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
                 edges,
                 migrations,
                 individuals,
+                mutations,
             }
         }
 
@@ -124,6 +127,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
                 provenances,
                 migrations,
                 individuals,
+                mutations,
             }
         }
     }
@@ -167,6 +171,7 @@ impl TableCollection {
         tables.edges.set_ptr(&(*tables.inner).edges);
         tables.migrations.set_ptr(&(*tables.inner).migrations);
         tables.individuals.set_ptr(&(*tables.inner).individuals);
+        tables.mutations.set_ptr(&(*tables.inner).mutations);
 
         #[cfg(feature = "provenance")]
         tables.provenances.set_ptr(&(*tables.inner).provenances);
@@ -1284,8 +1289,8 @@ impl TableAccess for TableCollection {
         &self.sites
     }
 
-    fn mutations(&self) -> MutationTable {
-        MutationTable::new_from_table(&(*self.inner).mutations)
+    fn mutations(&self) -> &MutationTable {
+        &self.mutations
     }
 
     fn populations(&self) -> &PopulationTable {

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -75,6 +75,7 @@ use mbox::MBox;
 pub struct TableCollection {
     pub(crate) inner: MBox<ll_bindings::tsk_table_collection_t>,
     populations: PopulationTable,
+    sites: SiteTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -92,12 +93,14 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
         };
         let mbox = unsafe { MBox::from_non_null_raw(nonnull) };
         let populations = PopulationTable::new_null();
+        let sites = SiteTable::new_null();
 
         #[cfg(not(feature = "provenance"))]
         {
             Self {
                 inner: mbox,
                 populations,
+                sites,
             }
         }
 
@@ -107,6 +110,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
             Self {
                 inner: mbox,
                 populations,
+                sites,
                 provenances,
             }
         }
@@ -147,6 +151,7 @@ impl TableCollection {
             (*tables.as_mut_ptr()).sequence_length = sequence_length.0;
         }
         tables.populations.set_ptr(&(*tables.inner).populations);
+        tables.sites.set_ptr(&(*tables.inner).sites);
 
         #[cfg(feature = "provenance")]
         tables.provenances.set_ptr(&(*tables.inner).provenances);
@@ -1260,8 +1265,8 @@ impl TableAccess for TableCollection {
         NodeTable::new_from_table(&(*self.inner).nodes)
     }
 
-    fn sites(&self) -> SiteTable {
-        SiteTable::new_from_table(&(*self.inner).sites)
+    fn sites(&self) -> &SiteTable {
+        &self.sites
     }
 
     fn mutations(&self) -> MutationTable {

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -78,6 +78,7 @@ pub struct TableCollection {
     sites: SiteTable,
     edges: EdgeTable,
     migrations: MigrationTable,
+    individuals: IndividualTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -98,6 +99,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
         let sites = SiteTable::new_null();
         let edges = EdgeTable::new_null();
         let migrations = MigrationTable::new_null();
+        let individuals = IndividualTable::new_null();
 
         #[cfg(not(feature = "provenance"))]
         {
@@ -107,6 +109,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
                 sites,
                 edges,
                 migrations,
+                individuals,
             }
         }
 
@@ -120,6 +123,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
                 edges,
                 provenances,
                 migrations,
+                individuals,
             }
         }
     }
@@ -162,6 +166,7 @@ impl TableCollection {
         tables.sites.set_ptr(&(*tables.inner).sites);
         tables.edges.set_ptr(&(*tables.inner).edges);
         tables.migrations.set_ptr(&(*tables.inner).migrations);
+        tables.individuals.set_ptr(&(*tables.inner).individuals);
 
         #[cfg(feature = "provenance")]
         tables.provenances.set_ptr(&(*tables.inner).provenances);
@@ -1263,8 +1268,8 @@ impl TableAccess for TableCollection {
         &self.edges
     }
 
-    fn individuals(&self) -> IndividualTable {
-        IndividualTable::new_from_table(&(*self.inner).individuals)
+    fn individuals(&self) -> &IndividualTable {
+        &self.individuals
     }
 
     fn migrations(&self) -> &MigrationTable {

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -65,6 +65,13 @@ use mbox::MBox;
 /// assert_eq!(nodes.num_rows(), 1);
 /// ```
 ///
+/// ```compile_fail
+/// use tskit::TableAccess;
+/// let tables = tskit::TableCollection::new(100.).unwrap();
+/// let populations = tables.populations();
+/// drop(tables);
+/// assert_eq!(populations.num_rows(), 0);
+/// ```
 pub struct TableCollection {
     pub(crate) inner: MBox<ll_bindings::tsk_table_collection_t>,
 }

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -77,6 +77,7 @@ pub struct TableCollection {
     populations: PopulationTable,
     sites: SiteTable,
     edges: EdgeTable,
+    migrations: MigrationTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -96,6 +97,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
         let populations = PopulationTable::new_null();
         let sites = SiteTable::new_null();
         let edges = EdgeTable::new_null();
+        let migrations = MigrationTable::new_null();
 
         #[cfg(not(feature = "provenance"))]
         {
@@ -104,6 +106,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
                 populations,
                 sites,
                 edges,
+                migrations,
             }
         }
 
@@ -116,6 +119,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
                 sites,
                 edges,
                 provenances,
+                migrations,
             }
         }
     }
@@ -1262,8 +1266,8 @@ impl TableAccess for TableCollection {
         IndividualTable::new_from_table(&(*self.inner).individuals)
     }
 
-    fn migrations(&self) -> MigrationTable {
-        MigrationTable::new_from_table(&(*self.inner).migrations)
+    fn migrations(&self) -> &MigrationTable {
+        &self.migrations
     }
 
     fn nodes(&self) -> NodeTable {

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -80,6 +80,7 @@ pub struct TableCollection {
     migrations: MigrationTable,
     individuals: IndividualTable,
     mutations: MutationTable,
+    nodes: NodeTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -102,6 +103,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
         let migrations = MigrationTable::new_null();
         let individuals = IndividualTable::new_null();
         let mutations = MutationTable::new_null();
+        let nodes = NodeTable::new_null();
 
         #[cfg(not(feature = "provenance"))]
         {
@@ -113,6 +115,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
                 migrations,
                 individuals,
                 mutations,
+                nodes,
             }
         }
 
@@ -128,6 +131,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
                 migrations,
                 individuals,
                 mutations,
+                nodes,
             }
         }
     }
@@ -172,6 +176,7 @@ impl TableCollection {
         tables.migrations.set_ptr(&(*tables.inner).migrations);
         tables.individuals.set_ptr(&(*tables.inner).individuals);
         tables.mutations.set_ptr(&(*tables.inner).mutations);
+        tables.nodes.set_ptr(&(*tables.inner).nodes);
 
         #[cfg(feature = "provenance")]
         tables.provenances.set_ptr(&(*tables.inner).provenances);
@@ -1281,8 +1286,8 @@ impl TableAccess for TableCollection {
         &self.migrations
     }
 
-    fn nodes(&self) -> NodeTable {
-        NodeTable::new_from_table(&(*self.inner).nodes)
+    fn nodes(&self) -> &NodeTable {
+        &self.nodes
     }
 
     fn sites(&self) -> &SiteTable {
@@ -1357,24 +1362,24 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_mutable_node_access() {
-        let tables = TableCollection::new(1000.).unwrap();
-        let mut nodes = tables.nodes();
-        let f = nodes.flags_array_mut();
-        for i in f {
-            *i = NodeFlags::from(11);
-        }
+    //#[test]
+    //fn test_mutable_node_access() {
+    //    let tables = TableCollection::new(1000.).unwrap();
+    //    let mut nodes = tables.nodes();
+    //    let f = nodes.flags_array_mut();
+    //    for i in f {
+    //        *i = NodeFlags::from(11);
+    //    }
 
-        for t in nodes.time_array_mut() {
-            *t = Time::from(-33.0);
-        }
+    //    for t in nodes.time_array_mut() {
+    //        *t = Time::from(-33.0);
+    //    }
 
-        for i in tables.nodes_iter() {
-            assert_eq!(i.flags.bits(), 11);
-            assert_eq!(f64::from(i.time) as i64, -33);
-        }
-    }
+    //    for i in tables.nodes_iter() {
+    //        assert_eq!(i.flags.bits(), 11);
+    //        assert_eq!(f64::from(i.time) as i64, -33);
+    //    }
+    //}
 
     #[test]
     fn test_node_iteration() {

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -161,6 +161,7 @@ impl TableCollection {
         tables.populations.set_ptr(&(*tables.inner).populations);
         tables.sites.set_ptr(&(*tables.inner).sites);
         tables.edges.set_ptr(&(*tables.inner).edges);
+        tables.migrations.set_ptr(&(*tables.inner).migrations);
 
         #[cfg(feature = "provenance")]
         tables.provenances.set_ptr(&(*tables.inner).provenances);

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -74,16 +74,7 @@ use mbox::MBox;
 /// ```
 pub struct TableCollection {
     pub(crate) inner: MBox<ll_bindings::tsk_table_collection_t>,
-    populations: PopulationTable,
-    sites: SiteTable,
-    edges: EdgeTable,
-    migrations: MigrationTable,
-    individuals: IndividualTable,
-    mutations: MutationTable,
-    nodes: NodeTable,
-
-    #[cfg(feature = "provenance")]
-    provenances: crate::provenance::ProvenanceTable,
+    table_references: crate::util::TableReferences,
 }
 
 impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCollection {
@@ -97,28 +88,11 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
             None => panic!("out of memory"),
         };
         let mbox = unsafe { MBox::from_non_null_raw(nonnull) };
-        let populations = PopulationTable::new_null();
-        let sites = SiteTable::new_null();
-        let edges = EdgeTable::new_null();
-        let migrations = MigrationTable::new_null();
-        let individuals = IndividualTable::new_null();
-        let mutations = MutationTable::new_null();
-        let nodes = NodeTable::new_null();
-
-        #[cfg(feature = "provenance")]
-        let provenances = crate::provenance::ProvenanceTable::new_null();
+        let table_references = crate::util::TableReferences::default();
 
         Self {
             inner: mbox,
-            populations,
-            sites,
-            edges,
-            migrations,
-            individuals,
-            mutations,
-            nodes,
-            #[cfg(feature = "provenance")]
-            provenances,
+            table_references,
         }
     }
 }
@@ -156,16 +130,40 @@ impl TableCollection {
         unsafe {
             (*tables.as_mut_ptr()).sequence_length = sequence_length.0;
         }
-        tables.populations.set_ptr(&(*tables.inner).populations);
-        tables.sites.set_ptr(&(*tables.inner).sites);
-        tables.edges.set_ptr(&(*tables.inner).edges);
-        tables.migrations.set_ptr(&(*tables.inner).migrations);
-        tables.individuals.set_ptr(&(*tables.inner).individuals);
-        tables.mutations.set_ptr(&(*tables.inner).mutations);
-        tables.nodes.set_ptr(&(*tables.inner).nodes);
+        tables
+            .table_references
+            .populations
+            .set_ptr(&(*tables.inner).populations);
+        tables
+            .table_references
+            .sites
+            .set_ptr(&(*tables.inner).sites);
+        tables
+            .table_references
+            .edges
+            .set_ptr(&(*tables.inner).edges);
+        tables
+            .table_references
+            .migrations
+            .set_ptr(&(*tables.inner).migrations);
+        tables
+            .table_references
+            .individuals
+            .set_ptr(&(*tables.inner).individuals);
+        tables
+            .table_references
+            .mutations
+            .set_ptr(&(*tables.inner).mutations);
+        tables
+            .table_references
+            .nodes
+            .set_ptr(&(*tables.inner).nodes);
 
         #[cfg(feature = "provenance")]
-        tables.provenances.set_ptr(&(*tables.inner).provenances);
+        tables
+            .table_references
+            .provenances
+            .set_ptr(&(*tables.inner).provenances);
 
         Ok(tables)
     }
@@ -1261,36 +1259,36 @@ impl TableCollection {
 
 impl TableAccess for TableCollection {
     fn edges(&self) -> &EdgeTable {
-        &self.edges
+        &self.table_references.edges
     }
 
     fn individuals(&self) -> &IndividualTable {
-        &self.individuals
+        &self.table_references.individuals
     }
 
     fn migrations(&self) -> &MigrationTable {
-        &self.migrations
+        &self.table_references.migrations
     }
 
     fn nodes(&self) -> &NodeTable {
-        &self.nodes
+        &self.table_references.nodes
     }
 
     fn sites(&self) -> &SiteTable {
-        &self.sites
+        &self.table_references.sites
     }
 
     fn mutations(&self) -> &MutationTable {
-        &self.mutations
+        &self.table_references.mutations
     }
 
     fn populations(&self) -> &PopulationTable {
-        &self.populations
+        &self.table_references.populations
     }
 
     #[cfg(any(feature = "provenance", doc))]
     fn provenances(&self) -> &crate::provenance::ProvenanceTable {
-        &self.provenances
+        &self.table_references.provenances
     }
 }
 

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -76,6 +76,7 @@ pub struct TableCollection {
     pub(crate) inner: MBox<ll_bindings::tsk_table_collection_t>,
     populations: PopulationTable,
     sites: SiteTable,
+    edges: EdgeTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -94,6 +95,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
         let mbox = unsafe { MBox::from_non_null_raw(nonnull) };
         let populations = PopulationTable::new_null();
         let sites = SiteTable::new_null();
+        let edges = EdgeTable::new_null();
 
         #[cfg(not(feature = "provenance"))]
         {
@@ -101,6 +103,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
                 inner: mbox,
                 populations,
                 sites,
+                edges,
             }
         }
 
@@ -111,6 +114,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
                 inner: mbox,
                 populations,
                 sites,
+                edges,
                 provenances,
             }
         }
@@ -152,6 +156,7 @@ impl TableCollection {
         }
         tables.populations.set_ptr(&(*tables.inner).populations);
         tables.sites.set_ptr(&(*tables.inner).sites);
+        tables.edges.set_ptr(&(*tables.inner).edges);
 
         #[cfg(feature = "provenance")]
         tables.provenances.set_ptr(&(*tables.inner).provenances);
@@ -1249,8 +1254,8 @@ impl TableCollection {
 }
 
 impl TableAccess for TableCollection {
-    fn edges(&self) -> EdgeTable {
-        EdgeTable::new_from_table(&(*self.inner).edges)
+    fn edges(&self) -> &EdgeTable {
+        &self.edges
     }
 
     fn individuals(&self) -> IndividualTable {

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -105,34 +105,20 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_table_collection_t> for TableCol
         let mutations = MutationTable::new_null();
         let nodes = NodeTable::new_null();
 
-        #[cfg(not(feature = "provenance"))]
-        {
-            Self {
-                inner: mbox,
-                populations,
-                sites,
-                edges,
-                migrations,
-                individuals,
-                mutations,
-                nodes,
-            }
-        }
-
         #[cfg(feature = "provenance")]
-        {
-            let provenances = crate::provenance::ProvenanceTable::new_null();
-            Self {
-                inner: mbox,
-                populations,
-                sites,
-                edges,
-                provenances,
-                migrations,
-                individuals,
-                mutations,
-                nodes,
-            }
+        let provenances = crate::provenance::ProvenanceTable::new_null();
+
+        Self {
+            inner: mbox,
+            populations,
+            sites,
+            edges,
+            migrations,
+            individuals,
+            mutations,
+            nodes,
+            #[cfg(feature = "provenance")]
+            provenances,
         }
     }
 }

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -1362,25 +1362,6 @@ mod test {
         }
     }
 
-    //#[test]
-    //fn test_mutable_node_access() {
-    //    let tables = TableCollection::new(1000.).unwrap();
-    //    let mut nodes = tables.nodes();
-    //    let f = nodes.flags_array_mut();
-    //    for i in f {
-    //        *i = NodeFlags::from(11);
-    //    }
-
-    //    for t in nodes.time_array_mut() {
-    //        *t = Time::from(-33.0);
-    //    }
-
-    //    for i in tables.nodes_iter() {
-    //        assert_eq!(i.flags.bits(), 11);
-    //        assert_eq!(f64::from(i.time) as i64, -33);
-    //    }
-    //}
-
     #[test]
     fn test_node_iteration() {
         let tables = make_small_table_collection();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -94,13 +94,13 @@ pub trait TableAccess {
     }
 
     /// Get reference to the [``MigrationTable``](crate::MigrationTable).
-    fn migrations(&self) -> MigrationTable;
+    fn migrations(&self) -> &MigrationTable;
 
     /// Return an iterator over the migration events.
     fn migrations_iter(
         &self,
     ) -> Box<dyn Iterator<Item = crate::migration_table::MigrationTableRow> + '_> {
-        Box::new(make_table_iterator::<MigrationTable>(self.migrations()))
+        Box::new(make_table_iterator::<&MigrationTable>(self.migrations()))
     }
 
     /// Get reference to the [``IndividualTable``](crate::IndividualTable).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -58,11 +58,11 @@ pub trait TableAccess {
     }
 
     /// Get reference to the [``NodeTable``](crate::NodeTable).
-    fn nodes(&self) -> NodeTable;
+    fn nodes(&self) -> &NodeTable;
 
     /// Return an iterator over the nodes.
     fn nodes_iter(&self) -> Box<dyn Iterator<Item = crate::node_table::NodeTableRow> + '_> {
-        Box::new(make_table_iterator::<NodeTable>(self.nodes()))
+        Box::new(make_table_iterator::<&NodeTable>(self.nodes()))
     }
 
     /// Get reference to the [``MutationTable``](crate::MutationTable).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -66,13 +66,13 @@ pub trait TableAccess {
     }
 
     /// Get reference to the [``MutationTable``](crate::MutationTable).
-    fn mutations(&self) -> MutationTable;
+    fn mutations(&self) -> &MutationTable;
 
     /// Return an iterator over the mutations.
     fn mutations_iter(
         &self,
     ) -> Box<dyn Iterator<Item = crate::mutation_table::MutationTableRow> + '_> {
-        Box::new(make_table_iterator::<MutationTable>(self.mutations()))
+        Box::new(make_table_iterator::<&MutationTable>(self.mutations()))
     }
 
     /// Get reference to the [``SiteTable``](crate::SiteTable).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -84,13 +84,13 @@ pub trait TableAccess {
     }
 
     /// Get reference to the [``PopulationTable``](crate::PopulationTable).
-    fn populations(&self) -> PopulationTable;
+    fn populations(&self) -> &PopulationTable;
 
     /// Return an iterator over the populations.
     fn populations_iter(
         &self,
     ) -> Box<dyn Iterator<Item = crate::population_table::PopulationTableRow> + '_> {
-        Box::new(make_table_iterator::<PopulationTable>(self.populations()))
+        Box::new(make_table_iterator::<&PopulationTable>(self.populations()))
     }
 
     /// Get reference to the [``MigrationTable``](crate::MigrationTable).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -104,13 +104,13 @@ pub trait TableAccess {
     }
 
     /// Get reference to the [``IndividualTable``](crate::IndividualTable).
-    fn individuals(&self) -> IndividualTable;
+    fn individuals(&self) -> &IndividualTable;
 
     /// Return an iterator over the individuals.
     fn individuals_iter(
         &self,
     ) -> Box<dyn Iterator<Item = crate::individual_table::IndividualTableRow> + '_> {
-        Box::new(make_table_iterator::<IndividualTable>(self.individuals()))
+        Box::new(make_table_iterator::<&IndividualTable>(self.individuals()))
     }
 
     #[cfg(any(feature = "provenance", doc))]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -115,7 +115,7 @@ pub trait TableAccess {
 
     #[cfg(any(feature = "provenance", doc))]
     /// Get reference to the [``ProvenanceTable``](crate::provenance::ProvenanceTable)
-    fn provenances(&self) -> crate::provenance::ProvenanceTable;
+    fn provenances(&self) -> &crate::provenance::ProvenanceTable;
 
     #[cfg(any(feature = "provenance", doc))]
     /// Return an iterator over provenances
@@ -123,7 +123,7 @@ pub trait TableAccess {
         &self,
     ) -> Box<dyn Iterator<Item = crate::provenance::ProvenanceTableRow> + '_> {
         Box::new(crate::table_iterator::make_table_iterator::<
-            crate::provenance::ProvenanceTable,
+            &crate::provenance::ProvenanceTable,
         >(self.provenances()))
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -76,11 +76,11 @@ pub trait TableAccess {
     }
 
     /// Get reference to the [``SiteTable``](crate::SiteTable).
-    fn sites(&self) -> SiteTable;
+    fn sites(&self) -> &SiteTable;
 
     /// Return an iterator over the sites.
     fn sites_iter(&self) -> Box<dyn Iterator<Item = crate::site_table::SiteTableRow> + '_> {
-        Box::new(make_table_iterator::<SiteTable>(self.sites()))
+        Box::new(make_table_iterator::<&SiteTable>(self.sites()))
     }
 
     /// Get reference to the [``PopulationTable``](crate::PopulationTable).

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -50,11 +50,11 @@ pub trait TskitTypeAccess<T> {
 /// ```
 pub trait TableAccess {
     /// Get reference to the [``EdgeTable``](crate::EdgeTable).
-    fn edges(&self) -> EdgeTable;
+    fn edges(&self) -> &EdgeTable;
 
     /// Return an iterator over the edges.
     fn edges_iter(&self) -> Box<dyn Iterator<Item = crate::edge_table::EdgeTableRow> + '_> {
-        Box::new(make_table_iterator::<EdgeTable>(self.edges()))
+        Box::new(make_table_iterator::<&EdgeTable>(self.edges()))
     }
 
     /// Get reference to the [``NodeTable``](crate::NodeTable).

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1052,6 +1052,10 @@ impl TreeSequence {
         let mut flags: u32 = flags.into().bits();
         flags |= ll_bindings::TSK_TAKE_OWNERSHIP;
         let raw_tables_ptr = tables.into_raw()?;
+        println!(
+            "here = {}",
+            unsafe { *(raw_tables_ptr) }.provenances.num_rows
+        );
         let rv =
             unsafe { ll_bindings::tsk_treeseq_init(treeseq.as_mut_ptr(), raw_tables_ptr, flags) };
         treeseq
@@ -1059,9 +1063,20 @@ impl TreeSequence {
             .set_ptr(&unsafe { *((*treeseq.inner).tables) }.populations);
         #[cfg(feature = "provenance")]
         {
+            let old_nrows = unsafe { unsafe { *(raw_tables_ptr) }.provenances.num_rows };
+            println!("here on the inside = {}", old_nrows,);
             treeseq
                 .provenances
                 .set_ptr(&unsafe { *(*treeseq.inner).tables }.provenances);
+            let old_nrows_again = unsafe { unsafe { *(raw_tables_ptr) }.provenances.num_rows };
+            assert_eq!(old_nrows, old_nrows_again);
+            let whats_happening =
+                unsafe { unsafe { (*(*treeseq.inner).tables) }.provenances.num_rows };
+            assert_eq!(
+                old_nrows, whats_happening,
+                "{} {}",
+                old_nrows, whats_happening
+            );
         }
         handle_tsk_return_value!(rv, treeseq)
     }

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1052,29 +1052,17 @@ impl TreeSequence {
         let mut flags: u32 = flags.into().bits();
         flags |= ll_bindings::TSK_TAKE_OWNERSHIP;
         let raw_tables_ptr = tables.into_raw()?;
-        println!(
-            "here = {}",
-            unsafe { *(raw_tables_ptr) }.provenances.num_rows
-        );
         let rv =
             unsafe { ll_bindings::tsk_treeseq_init(treeseq.as_mut_ptr(), raw_tables_ptr, flags) };
-        treeseq
-            .populations
-            .set_ptr(&unsafe { *((*treeseq.inner).tables) }.populations);
+        treeseq.populations.set_ptr(
+            &unsafe { *(*treeseq.inner).tables }.populations
+                as *const ll_bindings::tsk_population_table_t,
+        );
         #[cfg(feature = "provenance")]
         {
-            let old_nrows = unsafe { unsafe { *(raw_tables_ptr) }.provenances.num_rows };
-            println!("here on the inside = {}", old_nrows,);
-            treeseq
-                .provenances
-                .set_ptr(&unsafe { *(*treeseq.inner).tables }.provenances);
-            let old_nrows_again = unsafe { unsafe { *(raw_tables_ptr) }.provenances.num_rows };
-            assert_eq!(old_nrows, old_nrows_again);
-            let whats_happening = unsafe { (*(*treeseq.inner).tables) }.provenances.num_rows;
-            assert_eq!(
-                old_nrows, whats_happening,
-                "{} {}",
-                old_nrows, whats_happening
+            treeseq.provenances.set_ptr(
+                &unsafe { *(*treeseq.inner).tables }.provenances
+                    as *const ll_bindings::tsk_provenance_table_t,
             );
         }
         handle_tsk_return_value!(rv, treeseq)

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -958,16 +958,7 @@ iterator_for_nodeiterator!(SamplesIterator<'_>);
 /// ```
 pub struct TreeSequence {
     pub(crate) inner: MBox<ll_bindings::tsk_treeseq_t>,
-    populations: PopulationTable,
-    sites: SiteTable,
-    edges: EdgeTable,
-    migrations: MigrationTable,
-    individuals: IndividualTable,
-    mutations: MutationTable,
-    nodes: NodeTable,
-
-    #[cfg(feature = "provenance")]
-    provenances: crate::provenance::ProvenanceTable,
+    table_references: crate::util::TableReferences,
 }
 
 impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
@@ -981,27 +972,11 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
             None => panic!("out of memory"),
         };
         let mbox = unsafe { MBox::from_non_null_raw(nonnull) };
-        let populations = PopulationTable::new_null();
-        let sites = SiteTable::new_null();
-        let edges = EdgeTable::new_null();
-        let migrations = MigrationTable::new_null();
-        let individuals = IndividualTable::new_null();
-        let mutations = MutationTable::new_null();
-        let nodes = NodeTable::new_null();
+        let table_references = crate::util::TableReferences::default();
 
-        #[cfg(feature = "provenance")]
-        let provenances = crate::provenance::ProvenanceTable::new_null();
         Self {
             inner: mbox,
-            populations,
-            sites,
-            edges,
-            migrations,
-            individuals,
-            mutations,
-            nodes,
-            #[cfg(feature = "provenance")]
-            provenances,
+            table_references,
         }
     }
 }
@@ -1064,29 +1039,37 @@ impl TreeSequence {
         let rv =
             unsafe { ll_bindings::tsk_treeseq_init(treeseq.as_mut_ptr(), raw_tables_ptr, flags) };
         treeseq
+            .table_references
             .populations
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).populations });
         treeseq
+            .table_references
             .sites
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).sites });
         treeseq
+            .table_references
             .edges
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).edges });
         treeseq
+            .table_references
             .migrations
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).migrations });
         treeseq
+            .table_references
             .individuals
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).individuals });
         treeseq
+            .table_references
             .mutations
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).mutations });
         treeseq
+            .table_references
             .nodes
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).nodes });
         #[cfg(feature = "provenance")]
         {
             treeseq
+                .table_references
                 .provenances
                 .set_ptr(unsafe { &(*(*treeseq.inner).tables).provenances });
         }
@@ -1359,36 +1342,36 @@ impl TryFrom<TableCollection> for TreeSequence {
 
 impl TableAccess for TreeSequence {
     fn edges(&self) -> &EdgeTable {
-        &self.edges
+        &self.table_references.edges
     }
 
     fn individuals(&self) -> &IndividualTable {
-        &self.individuals
+        &self.table_references.individuals
     }
 
     fn migrations(&self) -> &MigrationTable {
-        &self.migrations
+        &self.table_references.migrations
     }
 
     fn nodes(&self) -> &NodeTable {
-        &self.nodes
+        &self.table_references.nodes
     }
 
     fn sites(&self) -> &SiteTable {
-        &self.sites
+        &self.table_references.sites
     }
 
     fn mutations(&self) -> &MutationTable {
-        &self.mutations
+        &self.table_references.mutations
     }
 
     fn populations(&self) -> &PopulationTable {
-        &self.populations
+        &self.table_references.populations
     }
 
     #[cfg(any(feature = "provenance", doc))]
     fn provenances(&self) -> &crate::provenance::ProvenanceTable {
-        &self.provenances
+        &self.table_references.provenances
     }
 }
 

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1322,10 +1322,6 @@ impl TreeSequence {
     /// ```
     pub fn add_provenance(&mut self, record: &str) -> Result<crate::ProvenanceId, TskitError> {
         let timestamp = humantime::format_rfc3339(std::time::SystemTime::now()).to_string();
-        assert_eq!(
-            unsafe { *(*self.inner).tables }.provenances.num_rows,
-            self.provenances().num_rows()
-        );
         let rv = unsafe {
             ll_bindings::tsk_provenance_table_add_row(
                 &mut (*(*self.inner).tables).provenances,

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -988,34 +988,20 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
         let individuals = IndividualTable::new_null();
         let mutations = MutationTable::new_null();
         let nodes = NodeTable::new_null();
-        #[cfg(not(feature = "provenance"))]
-        {
-            Self {
-                inner: mbox,
-                populations,
-                sites,
-                edges,
-                migrations,
-                individuals,
-                mutations,
-                nodes,
-            }
-        }
 
         #[cfg(feature = "provenance")]
-        {
-            let provenances = crate::provenance::ProvenanceTable::new_null();
-            Self {
-                inner: mbox,
-                populations,
-                sites,
-                edges,
-                migrations,
-                individuals,
-                mutations,
-                nodes,
-                provenances,
-            }
+        let provenances = crate::provenance::ProvenanceTable::new_null();
+        Self {
+            inner: mbox,
+            populations,
+            sites,
+            edges,
+            migrations,
+            individuals,
+            mutations,
+            nodes,
+            #[cfg(feature = "provenance")]
+            provenances,
         }
     }
 }

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -964,6 +964,7 @@ pub struct TreeSequence {
     edges: EdgeTable,
     migrations: MigrationTable,
     individuals: IndividualTable,
+    mutations: MutationTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -985,6 +986,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
         let edges = EdgeTable::new_null();
         let migrations = MigrationTable::new_null();
         let individuals = IndividualTable::new_null();
+        let mutations = MutationTable::new_null();
         #[cfg(not(feature = "provenance"))]
         {
             Self {
@@ -994,6 +996,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
                 edges,
                 migrations,
                 individuals,
+                mutations,
             }
         }
 
@@ -1007,6 +1010,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
                 edges,
                 migrations,
                 individuals,
+                mutations,
                 provenances,
             }
         }
@@ -1085,6 +1089,9 @@ impl TreeSequence {
         treeseq
             .individuals
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).individuals });
+        treeseq
+            .mutations
+            .set_ptr(unsafe { &(*(*treeseq.inner).tables).mutations });
         #[cfg(feature = "provenance")]
         {
             treeseq
@@ -1379,8 +1386,8 @@ impl TableAccess for TreeSequence {
         &self.sites
     }
 
-    fn mutations(&self) -> MutationTable {
-        MutationTable::new_from_table(unsafe { &(*(*self.inner).tables).mutations })
+    fn mutations(&self) -> &MutationTable {
+        &self.mutations
     }
 
     fn populations(&self) -> &PopulationTable {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1061,7 +1061,7 @@ impl TreeSequence {
         {
             treeseq
                 .provenances
-                .set_ptr(&unsafe { *((*treeseq.inner).tables) }.provenances);
+                .set_ptr(&unsafe { *(*treeseq.inner).tables }.provenances);
         }
         handle_tsk_return_value!(rv, treeseq)
     }

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -524,10 +524,9 @@ impl Tree {
     /// (and the tree sequence from which it came).
     ///
     /// This is a convenience function for accessing node times, etc..
-    pub fn node_table<'a>(&'a self) -> crate::NodeTable<'a> {
-        crate::NodeTable::<'a>::new_from_table(unsafe {
-            &(*(*(*self.inner).tree_sequence).tables).nodes
-        })
+    pub fn node_table(&self) -> crate::NodeTable {
+        unimplemented!("we haven't done this one right yet");
+        crate::NodeTable::new_from_table(unsafe { &(*(*(*self.inner).tree_sequence).tables).nodes })
     }
 
     /// Calculate the total length of the tree via a preorder traversal.
@@ -965,6 +964,7 @@ pub struct TreeSequence {
     migrations: MigrationTable,
     individuals: IndividualTable,
     mutations: MutationTable,
+    nodes: NodeTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -987,6 +987,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
         let migrations = MigrationTable::new_null();
         let individuals = IndividualTable::new_null();
         let mutations = MutationTable::new_null();
+        let nodes = NodeTable::new_null();
         #[cfg(not(feature = "provenance"))]
         {
             Self {
@@ -997,6 +998,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
                 migrations,
                 individuals,
                 mutations,
+                nodes,
             }
         }
 
@@ -1011,6 +1013,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
                 migrations,
                 individuals,
                 mutations,
+                nodes,
                 provenances,
             }
         }
@@ -1092,6 +1095,9 @@ impl TreeSequence {
         treeseq
             .mutations
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).mutations });
+        treeseq
+            .nodes
+            .set_ptr(unsafe { &(*(*treeseq.inner).tables).nodes });
         #[cfg(feature = "provenance")]
         {
             treeseq
@@ -1378,8 +1384,8 @@ impl TableAccess for TreeSequence {
         &self.migrations
     }
 
-    fn nodes(&self) -> NodeTable {
-        NodeTable::new_from_table(unsafe { &(*(*self.inner).tables).nodes })
+    fn nodes(&self) -> &NodeTable {
+        &self.nodes
     }
 
     fn sites(&self) -> &SiteTable {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -33,6 +33,7 @@ pub struct Tree {
     num_nodes: tsk_size_t,
     array_len: tsk_size_t,
     flags: TreeFlags,
+    nodes: NodeTable,
 }
 
 // Trait defining iteration over nodes.
@@ -54,6 +55,7 @@ impl Tree {
             panic!("out of memory");
         }
         let mbox = unsafe { MBox::from_raw(temp.cast::<ll_bindings::tsk_tree_t>()) };
+        let nodes = NodeTable::new_null();
         Self {
             inner: mbox,
             current_tree: 0,
@@ -61,6 +63,7 @@ impl Tree {
             num_nodes,
             array_len: num_nodes + 1,
             flags,
+            nodes,
         }
     }
 
@@ -82,6 +85,9 @@ impl Tree {
                 )
             };
         }
+
+        tree.nodes
+            .set_ptr(unsafe { &(*(*(*tree.inner).tree_sequence).tables).nodes });
 
         handle_tsk_return_value!(rv, tree)
     }
@@ -525,7 +531,6 @@ impl Tree {
     ///
     /// This is a convenience function for accessing node times, etc..
     pub fn node_table(&self) -> crate::NodeTable {
-        unimplemented!("we haven't done this one right yet");
         crate::NodeTable::new_from_table(unsafe { &(*(*(*self.inner).tree_sequence).tables).nodes })
     }
 

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -960,6 +960,7 @@ iterator_for_nodeiterator!(SamplesIterator<'_>);
 pub struct TreeSequence {
     pub(crate) inner: MBox<ll_bindings::tsk_treeseq_t>,
     populations: PopulationTable,
+    sites: SiteTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -977,11 +978,13 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
         };
         let mbox = unsafe { MBox::from_non_null_raw(nonnull) };
         let populations = PopulationTable::new_null();
+        let sites = SiteTable::new_null();
         #[cfg(not(feature = "provenance"))]
         {
             Self {
                 inner: mbox,
                 populations,
+                sites,
             }
         }
 
@@ -991,6 +994,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
             Self {
                 inner: mbox,
                 populations,
+                sites,
                 provenances,
             }
         }
@@ -1057,6 +1061,9 @@ impl TreeSequence {
         treeseq
             .populations
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).populations });
+        treeseq
+            .sites
+            .set_ptr(unsafe { &(*(*treeseq.inner).tables).sites });
         #[cfg(feature = "provenance")]
         {
             treeseq
@@ -1347,8 +1354,8 @@ impl TableAccess for TreeSequence {
         NodeTable::new_from_table(unsafe { &(*(*self.inner).tables).nodes })
     }
 
-    fn sites(&self) -> SiteTable {
-        SiteTable::new_from_table(unsafe { &(*(*self.inner).tables).sites })
+    fn sites(&self) -> &SiteTable {
+        &self.sites
     }
 
     fn mutations(&self) -> MutationTable {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1056,12 +1056,12 @@ impl TreeSequence {
             unsafe { ll_bindings::tsk_treeseq_init(treeseq.as_mut_ptr(), raw_tables_ptr, flags) };
         treeseq
             .populations
-            .set_ptr(&unsafe { *(*treeseq.inner).tables }.populations);
+            .set_ptr(unsafe { &(*(*treeseq.inner).tables).populations });
         #[cfg(feature = "provenance")]
         {
             treeseq
                 .provenances
-                .set_ptr(&unsafe { *(*treeseq.inner).tables }.provenances);
+                .set_ptr(unsafe { &(*(*treeseq.inner).tables).provenances });
         }
 
         handle_tsk_return_value!(rv, treeseq)

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -961,6 +961,7 @@ pub struct TreeSequence {
     pub(crate) inner: MBox<ll_bindings::tsk_treeseq_t>,
     populations: PopulationTable,
     sites: SiteTable,
+    edges: EdgeTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -979,12 +980,14 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
         let mbox = unsafe { MBox::from_non_null_raw(nonnull) };
         let populations = PopulationTable::new_null();
         let sites = SiteTable::new_null();
+        let edges = EdgeTable::new_null();
         #[cfg(not(feature = "provenance"))]
         {
             Self {
                 inner: mbox,
                 populations,
                 sites,
+                edges,
             }
         }
 
@@ -995,6 +998,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
                 inner: mbox,
                 populations,
                 sites,
+                edges,
                 provenances,
             }
         }
@@ -1064,6 +1068,9 @@ impl TreeSequence {
         treeseq
             .sites
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).sites });
+        treeseq
+            .edges
+            .set_ptr(unsafe { &(*(*treeseq.inner).tables).edges });
         #[cfg(feature = "provenance")]
         {
             treeseq
@@ -1338,8 +1345,8 @@ impl TryFrom<TableCollection> for TreeSequence {
 }
 
 impl TableAccess for TreeSequence {
-    fn edges(&self) -> EdgeTable {
-        EdgeTable::new_from_table(unsafe { &(*(*self.inner).tables).edges })
+    fn edges(&self) -> &EdgeTable {
+        &self.edges
     }
 
     fn individuals(&self) -> IndividualTable {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1058,9 +1058,12 @@ impl TreeSequence {
             .populations
             .set_ptr(&unsafe { *(*treeseq.inner).tables }.populations);
         #[cfg(feature = "provenance")]
-        treeseq
-            .provenances
-            .set_ptr(&unsafe { *(*treeseq.inner).tables }.provenances);
+        {
+            treeseq
+                .provenances
+                .set_ptr(&unsafe { *(*treeseq.inner).tables }.provenances);
+        }
+
         handle_tsk_return_value!(rv, treeseq)
     }
 
@@ -1308,7 +1311,8 @@ impl TreeSequence {
         let timestamp = humantime::format_rfc3339(std::time::SystemTime::now()).to_string();
         let rv = unsafe {
             ll_bindings::tsk_provenance_table_add_row(
-                &mut (*(*self.inner).tables).provenances,
+                &mut (*(*self.inner).tables).provenances
+                    as *mut ll_bindings::tsk_provenance_table_t,
                 timestamp.as_ptr() as *mut i8,
                 timestamp.len() as tsk_size_t,
                 record.as_ptr() as *mut i8,

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -962,6 +962,7 @@ pub struct TreeSequence {
     populations: PopulationTable,
     sites: SiteTable,
     edges: EdgeTable,
+    migrations: MigrationTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -981,6 +982,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
         let populations = PopulationTable::new_null();
         let sites = SiteTable::new_null();
         let edges = EdgeTable::new_null();
+        let migrations = MigrationTable::new_null();
         #[cfg(not(feature = "provenance"))]
         {
             Self {
@@ -988,6 +990,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
                 populations,
                 sites,
                 edges,
+                migrations,
             }
         }
 
@@ -999,6 +1002,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
                 populations,
                 sites,
                 edges,
+                migrations,
                 provenances,
             }
         }
@@ -1071,6 +1075,9 @@ impl TreeSequence {
         treeseq
             .edges
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).edges });
+        treeseq
+            .migrations
+            .set_ptr(unsafe { &(*(*treeseq.inner).tables).migrations });
         #[cfg(feature = "provenance")]
         {
             treeseq
@@ -1353,8 +1360,8 @@ impl TableAccess for TreeSequence {
         IndividualTable::new_from_table(unsafe { &(*(*self.inner).tables).individuals })
     }
 
-    fn migrations(&self) -> MigrationTable {
-        MigrationTable::new_from_table(unsafe { &(*(*self.inner).tables).migrations })
+    fn migrations(&self) -> &MigrationTable {
+        &self.migrations
     }
 
     fn nodes(&self) -> NodeTable {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1431,6 +1431,7 @@ pub(crate) mod test_trees {
             ntrees += 1;
             assert_eq!(tree.current_tree, ntrees);
             let samples = tree.sample_nodes();
+            let _ = tree.node_table();
             assert_eq!(samples.len(), 2);
             for i in 1..3 {
                 assert_eq!(samples[i - 1], NodeId::from(i as tsk_id_t));

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1054,17 +1054,13 @@ impl TreeSequence {
         let raw_tables_ptr = tables.into_raw()?;
         let rv =
             unsafe { ll_bindings::tsk_treeseq_init(treeseq.as_mut_ptr(), raw_tables_ptr, flags) };
-        treeseq.populations.set_ptr(
-            &unsafe { *(*treeseq.inner).tables }.populations
-                as *const ll_bindings::tsk_population_table_t,
-        );
+        treeseq
+            .populations
+            .set_ptr(&unsafe { *(*treeseq.inner).tables }.populations);
         #[cfg(feature = "provenance")]
-        {
-            treeseq.provenances.set_ptr(
-                &unsafe { *(*treeseq.inner).tables }.provenances
-                    as *const ll_bindings::tsk_provenance_table_t,
-            );
-        }
+        treeseq
+            .provenances
+            .set_ptr(&unsafe { *(*treeseq.inner).tables }.provenances);
         handle_tsk_return_value!(rv, treeseq)
     }
 

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -959,9 +959,30 @@ iterator_for_nodeiterator!(SamplesIterator<'_>);
 /// ```
 pub struct TreeSequence {
     pub(crate) inner: MBox<ll_bindings::tsk_treeseq_t>,
+    populations: PopulationTable,
 }
 
-build_tskit_type!(TreeSequence, ll_bindings::tsk_treeseq_t, tsk_treeseq_free);
+impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
+    fn wrap() -> Self {
+        let temp = unsafe {
+            libc::malloc(std::mem::size_of::<ll_bindings::tsk_treeseq_t>())
+                as *mut ll_bindings::tsk_treeseq_t
+        };
+        let nonnull = match std::ptr::NonNull::<ll_bindings::tsk_treeseq_t>::new(temp) {
+            Some(x) => x,
+            None => panic!("out of memory"),
+        };
+        let mbox = unsafe { MBox::from_non_null_raw(nonnull) };
+        let populations = PopulationTable::new_null();
+        Self {
+            inner: mbox,
+            populations,
+        }
+    }
+}
+
+drop_for_tskit_type!(TreeSequence, tsk_treeseq_free);
+tskit_type_access!(TreeSequence, ll_bindings::tsk_treeseq_t);
 
 impl TreeSequence {
     /// Create a tree sequence from a [`TableCollection`].
@@ -1017,6 +1038,9 @@ impl TreeSequence {
         let raw_tables_ptr = tables.into_raw()?;
         let rv =
             unsafe { ll_bindings::tsk_treeseq_init(treeseq.as_mut_ptr(), raw_tables_ptr, flags) };
+        treeseq
+            .populations
+            .set_ptr(&unsafe { *((*treeseq.inner).tables) }.populations);
         handle_tsk_return_value!(rv, treeseq)
     }
 
@@ -1308,8 +1332,8 @@ impl TableAccess for TreeSequence {
         MutationTable::new_from_table(unsafe { &(*(*self.inner).tables).mutations })
     }
 
-    fn populations(&self) -> PopulationTable {
-        PopulationTable::new_from_table(unsafe { &(*(*self.inner).tables).populations })
+    fn populations(&self) -> &PopulationTable {
+        &self.populations
     }
 
     #[cfg(any(feature = "provenance", doc))]

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -963,6 +963,7 @@ pub struct TreeSequence {
     sites: SiteTable,
     edges: EdgeTable,
     migrations: MigrationTable,
+    individuals: IndividualTable,
 
     #[cfg(feature = "provenance")]
     provenances: crate::provenance::ProvenanceTable,
@@ -983,6 +984,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
         let sites = SiteTable::new_null();
         let edges = EdgeTable::new_null();
         let migrations = MigrationTable::new_null();
+        let individuals = IndividualTable::new_null();
         #[cfg(not(feature = "provenance"))]
         {
             Self {
@@ -991,6 +993,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
                 sites,
                 edges,
                 migrations,
+                individuals,
             }
         }
 
@@ -1003,6 +1006,7 @@ impl crate::ffi::WrapTskitType<ll_bindings::tsk_treeseq_t> for TreeSequence {
                 sites,
                 edges,
                 migrations,
+                individuals,
                 provenances,
             }
         }
@@ -1078,6 +1082,9 @@ impl TreeSequence {
         treeseq
             .migrations
             .set_ptr(unsafe { &(*(*treeseq.inner).tables).migrations });
+        treeseq
+            .individuals
+            .set_ptr(unsafe { &(*(*treeseq.inner).tables).individuals });
         #[cfg(feature = "provenance")]
         {
             treeseq
@@ -1356,8 +1363,8 @@ impl TableAccess for TreeSequence {
         &self.edges
     }
 
-    fn individuals(&self) -> IndividualTable {
-        IndividualTable::new_from_table(unsafe { &(*(*self.inner).tables).individuals })
+    fn individuals(&self) -> &IndividualTable {
+        &self.individuals
     }
 
     fn migrations(&self) -> &MigrationTable {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1070,8 +1070,7 @@ impl TreeSequence {
                 .set_ptr(&unsafe { *(*treeseq.inner).tables }.provenances);
             let old_nrows_again = unsafe { unsafe { *(raw_tables_ptr) }.provenances.num_rows };
             assert_eq!(old_nrows, old_nrows_again);
-            let whats_happening =
-                unsafe { unsafe { (*(*treeseq.inner).tables) }.provenances.num_rows };
+            let whats_happening = unsafe { (*(*treeseq.inner).tables) }.provenances.num_rows;
             assert_eq!(
                 old_nrows, whats_happening,
                 "{} {}",
@@ -1323,6 +1322,10 @@ impl TreeSequence {
     /// ```
     pub fn add_provenance(&mut self, record: &str) -> Result<crate::ProvenanceId, TskitError> {
         let timestamp = humantime::format_rfc3339(std::time::SystemTime::now()).to_string();
+        assert_eq!(
+            unsafe { *(*self.inner).tables }.provenances.num_rows,
+            self.provenances().num_rows()
+        );
         let rv = unsafe {
             ll_bindings::tsk_provenance_table_add_row(
                 &mut (*(*self.inner).tables).provenances,

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1311,8 +1311,7 @@ impl TreeSequence {
         let timestamp = humantime::format_rfc3339(std::time::SystemTime::now()).to_string();
         let rv = unsafe {
             ll_bindings::tsk_provenance_table_add_row(
-                &mut (*(*self.inner).tables).provenances
-                    as *mut ll_bindings::tsk_provenance_table_t,
+                &mut (*(*self.inner).tables).provenances,
                 timestamp.as_ptr() as *mut i8,
                 timestamp.len() as tsk_size_t,
                 record.as_ptr() as *mut i8,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,36 @@
+use crate::{
+    EdgeTable, IndividualTable, MigrationTable, MutationTable, NodeTable, PopulationTable,
+    SiteTable,
+};
+
 pub(crate) fn partial_cmp_equal<T: PartialOrd>(lhs: &T, rhs: &T) -> bool {
     matches!(lhs.partial_cmp(rhs), Some(std::cmp::Ordering::Equal))
+}
+
+pub(crate) struct TableReferences {
+    pub edges: EdgeTable,
+    pub nodes: NodeTable,
+    pub sites: SiteTable,
+    pub mutations: MutationTable,
+    pub individuals: IndividualTable,
+    pub migrations: MigrationTable,
+    pub populations: PopulationTable,
+    #[cfg(feature = "provenance")]
+    pub provenances: crate::provenance::ProvenanceTable,
+}
+
+impl Default for TableReferences {
+    fn default() -> Self {
+        Self {
+            edges: EdgeTable::new_null(),
+            nodes: NodeTable::new_null(),
+            sites: SiteTable::new_null(),
+            mutations: MutationTable::new_null(),
+            individuals: IndividualTable::new_null(),
+            migrations: MigrationTable::new_null(),
+            populations: PopulationTable::new_null(),
+            #[cfg(feature = "provenance")]
+            provenances: crate::provenance::ProvenanceTable::new_null(),
+        }
+    }
 }


### PR DESCRIPTION
Table types are currently defined as `EdgeTable<'a>`,
where the lifetime is that of the table collection
owning the tables.

We need to relax this lifetime bound in order to 
support standalone tables.

This PR:

* Removes the lifetime bounds from each table type.
  They now store `*const` instead of `&'a` references
  to the low-level table type.
* Refactors the initialization of TreeSequence and
  TableCollection to store instances of the table
  types.
* Changes the return types of `TableAccess` functions
  to be `&Table` instead of `Table`.

These changes will go into a new version number.
The last change is technically a break change:
client codes implementing the trait will have their
implementations break. However, I suspect no one has
done so.
