### PR TITLE
refactor tree iteration

### DIFF
--- a/src/tree_interface.rs
+++ b/src/tree_interface.rs
@@ -10,6 +10,7 @@ use crate::TskitError;
 use crate::TskitTypeAccess;
 use std::ptr::NonNull;
 
+#[derive(Debug)]
 pub struct TreeInterface {
     non_owned_pointer: NonNull<ll_bindings::tsk_tree_t>,
     num_nodes: tsk_size_t,

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -50,6 +50,7 @@ impl TreeIterator {
         assert_eq!(rv, 0);
         let tree = unsafe { tree.assume_init() };
 
+        unimplemented!("need to handle num_nodes, etc...");
         Self {
             tree,
             current_tree: -1,

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -787,18 +787,19 @@ pub(crate) mod test_trees {
     fn test_new_trees_iterator() {
         let treeseq = treeseq_from_small_table_collection();
         for tree in treeseq.trees() {
-            let parents = unsafe {
-                std::slice::from_raw_parts((*tree.tree.as_ptr()).parent as *const NodeId, 4_usize)
-            };
-            println!("{:?}", parents);
+            for n in tree.traverse_nodes(NodeTraversalOrder::Preorder) {
+                for p in tree.parents(n).unwrap() {
+                    println!("{:?}", p);
+                }
+            }
         }
 
         // This is a safety sticking point:
         // we cannot collect the iterable itself b/c
         // the underlying tree memory is re-used.
-        let i = treeseq.trees();
-        let v = Vec::<Tree>::from_iter(i);
-        assert_eq!(v.len(), 2);
+        // let i = treeseq.trees();
+        // let v = Vec::<Tree>::from_iter(i);
+        // assert_eq!(v.len(), 2);
     }
 
     #[should_panic]

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -767,6 +767,10 @@ pub(crate) mod test_trees {
             }
         }
 
+        // NOTE: the following blocks make cargo valgrind crash,
+        // which is a sign of badness.
+        panic!("cargo valgrind will fail here");
+
         // This is a safety sticking point:
         // we cannot collect the iterable itself b/c
         // the underlying tree memory is re-used.

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1,3 +1,4 @@
+use std::mem::MaybeUninit;
 use std::ptr::NonNull;
 
 use crate::bindings as ll_bindings;
@@ -43,6 +44,23 @@ pub struct TreeIterator {
 }
 
 impl TreeIterator {
+    // FIXME: init if fallible!
+    fn new(treeseq: &TreeSequence) -> Self {
+        let mut tree = MaybeUninit::<ll_bindings::tsk_tree_t>::uninit();
+        let _rv = unsafe {
+            ll_bindings::tsk_tree_init(tree.as_mut_ptr(), treeseq.inner.as_ref(), 0);
+        };
+        let tree = unsafe { tree.assume_init() };
+
+        Self {
+            tree,
+            current_tree: -1,
+            advanced: false,
+            num_nodes: 0,
+            array_len: 0,
+            flags: 0.into(),
+        }
+    }
     fn item(&mut self) -> NonOwningTree {
         NonOwningTree::new(
             NonNull::from(&mut self.tree),

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -161,6 +161,12 @@ impl Deref for Tree {
     }
 }
 
+impl Drop for Tree {
+    fn drop(&mut self) {
+        let rv = unsafe { ll_bindings::tsk_tree_free(&mut self.inner) };
+    }
+}
+
 impl DerefMut for Tree {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.api

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -46,9 +46,8 @@ impl TreeIterator {
     // FIXME: init if fallible!
     fn new(treeseq: &TreeSequence) -> Self {
         let mut tree = MaybeUninit::<ll_bindings::tsk_tree_t>::uninit();
-        let _rv = unsafe {
-            ll_bindings::tsk_tree_init(tree.as_mut_ptr(), treeseq.as_ptr(), 0);
-        };
+        let rv = unsafe { ll_bindings::tsk_tree_init(tree.as_mut_ptr(), treeseq.as_ptr(), 0) };
+        assert_eq!(rv, 0);
         let tree = unsafe { tree.assume_init() };
 
         Self {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -42,20 +42,6 @@ pub struct TreeIterator {
     flags: TreeFlags,
 }
 
-impl FromIterator<NonOwningTree> for Vec<Tree> {
-    fn from_iter<T: IntoIterator<Item = NonOwningTree>>(iter: T) -> Self {
-        let mut out = vec![];
-        for i in iter {
-            let mut lltree = MaybeUninit::<ll_bindings::tsk_tree_t>::uninit();
-            // NOTE: the following is fallible, but this function is not meant to be
-            let rv = unsafe { ll_bindings::tsk_tree_copy(i.tree.as_ptr(), lltree.as_mut_ptr(), 0) };
-            assert_eq!(rv, 0);
-            unimplemented!("not yet!");
-        }
-        out
-    }
-}
-
 impl TreeIterator {
     // FIXME: init if fallible!
     fn new(treeseq: &TreeSequence) -> Self {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -101,6 +101,10 @@ impl NonOwningTree {
             flags,
         }
     }
+
+    fn as_owned(&self) -> &Self {
+        self
+    }
 }
 
 impl Iterator for TreeIterator {
@@ -753,9 +757,23 @@ pub(crate) mod test_trees {
             assert_eq!(tree.num_tracked_samples(1.into()).unwrap(), 1);
             assert_eq!(tree.num_tracked_samples(0.into()).unwrap(), 2);
         }
+    }
+
+    #[test]
+    fn test_trees() {
+        let treeseq = treeseq_from_small_table_collection();
         for tree in treeseq.trees() {
             println!("{:?}", tree);
         }
+
+        // This is a safety sticking point:
+        // we cannot collect the iterable itself b/c
+        // the underlying tree memory is re-used.
+        let v = treeseq
+            .trees()
+            .map(|t| t.as_owned()) // this is what we mean, but this is broken
+            .collect::<Vec<NonOwningTree>>();
+        assert_eq!(v.len(), 2);
     }
 
     #[should_panic]

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -164,6 +164,7 @@ impl Deref for Tree {
 impl Drop for Tree {
     fn drop(&mut self) {
         let rv = unsafe { ll_bindings::tsk_tree_free(&mut self.inner) };
+        assert_eq!(rv, 0);
     }
 }
 

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1,6 +1,5 @@
 use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
-use std::ptr::NonNull;
 
 use crate::bindings as ll_bindings;
 use crate::error::TskitError;
@@ -22,7 +21,6 @@ use crate::TreeSequenceFlags;
 use crate::TskReturnValue;
 use crate::TskitTypeAccess;
 use crate::{tsk_id_t, tsk_size_t, TableCollection};
-use ll_bindings::tsk_tree_free;
 use std::ptr::NonNull;
 
 /// A Tree.
@@ -59,7 +57,7 @@ impl TreeIterator {
     fn new(treeseq: &TreeSequence) -> Self {
         let mut tree = MaybeUninit::<ll_bindings::tsk_tree_t>::uninit();
         let _rv = unsafe {
-            ll_bindings::tsk_tree_init(tree.as_mut_ptr(), treeseq.inner.as_ref(), 0);
+            ll_bindings::tsk_tree_init(tree.as_mut_ptr(), treeseq.as_ptr(), 0);
         };
         let tree = unsafe { tree.assume_init() };
 

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -73,6 +73,7 @@ impl TreeIterator {
     }
 }
 
+#[derive(Debug)]
 pub struct NonOwningTree {
     tree: NonNull<ll_bindings::tsk_tree_t>,
     current_tree: i32,
@@ -439,6 +440,11 @@ impl TreeSequence {
         Ok(tree)
     }
 
+    /// Return an iterator over the trees.
+    pub fn trees(&self) -> impl Iterator<Item = NonOwningTree> + '_ {
+        TreeIterator::new(self)
+    }
+
     /// Get the list of samples as a vector.
     /// # Panics
     ///
@@ -746,6 +752,9 @@ pub(crate) mod test_trees {
             assert_eq!(tree.num_tracked_samples(2.into()).unwrap(), 1);
             assert_eq!(tree.num_tracked_samples(1.into()).unwrap(), 1);
             assert_eq!(tree.num_tracked_samples(0.into()).unwrap(), 2);
+        }
+        for tree in treeseq.trees() {
+            println!("{:?}", tree);
         }
     }
 

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -110,6 +110,12 @@ impl Iterator for TreeIterator {
     }
 }
 
+impl Drop for TreeIterator {
+    fn drop(&mut self) {
+        unsafe { ll_bindings::tsk_tree_free(&mut self.tree) };
+    }
+}
+
 // Trait defining iteration over nodes.
 trait NodeIterator {
     fn next_node(&mut self);

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -62,8 +62,6 @@ impl TreeIterator {
     fn item(&mut self) -> NonOwningTree {
         NonOwningTree::new(
             NonNull::from(&mut self.tree),
-            self.current_tree,
-            self.advanced,
             self.num_nodes,
             self.array_len,
             self.flags,
@@ -73,13 +71,7 @@ impl TreeIterator {
 
 #[derive(Debug)]
 pub struct NonOwningTree {
-    tree: NonNull<ll_bindings::tsk_tree_t>,
     api: TreeInterface,
-    current_tree: i32,
-    advanced: bool,
-    num_nodes: tsk_size_t,
-    array_len: tsk_size_t,
-    flags: TreeFlags,
 }
 
 impl Deref for NonOwningTree {
@@ -93,26 +85,14 @@ impl Deref for NonOwningTree {
 impl NonOwningTree {
     fn new(
         tree: NonNull<ll_bindings::tsk_tree_t>,
-        current_tree: i32,
-        advanced: bool,
         num_nodes: tsk_size_t,
         array_len: tsk_size_t,
         flags: TreeFlags,
     ) -> Self {
         let api = TreeInterface::new(tree, num_nodes, array_len, flags);
         Self {
-            tree,
             api,
-            current_tree,
-            advanced,
-            num_nodes,
-            array_len,
-            flags,
         }
-    }
-
-    fn as_owned(&self) -> &Self {
-        self
     }
 }
 

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -89,11 +89,20 @@ impl TreeIterator {
 #[derive(Debug)]
 pub struct NonOwningTree {
     tree: NonNull<ll_bindings::tsk_tree_t>,
+    api: TreeInterface,
     current_tree: i32,
     advanced: bool,
     num_nodes: tsk_size_t,
     array_len: tsk_size_t,
     flags: TreeFlags,
+}
+
+impl Deref for NonOwningTree {
+    type Target = TreeInterface;
+
+    fn deref(&self) -> &Self::Target {
+        &self.api
+    }
 }
 
 impl NonOwningTree {
@@ -105,8 +114,10 @@ impl NonOwningTree {
         array_len: tsk_size_t,
         flags: TreeFlags,
     ) -> Self {
+        let api = TreeInterface::new(tree, num_nodes, array_len, flags);
         Self {
             tree,
+            api,
             current_tree,
             advanced,
             num_nodes,
@@ -458,7 +469,7 @@ impl TreeSequence {
     }
 
     /// Return an iterator over the trees.
-    pub fn trees(&self) -> impl Iterator<Item = NonOwningTree> + '_ {
+    pub fn trees(&self) -> impl Iterator<Item = impl Deref<Target = TreeInterface>> + '_ {
         TreeIterator::new(self)
     }
 

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -760,10 +760,13 @@ pub(crate) mod test_trees {
     }
 
     #[test]
-    fn test_trees() {
+    fn test_new_trees_iterator() {
         let treeseq = treeseq_from_small_table_collection();
         for tree in treeseq.trees() {
-            println!("{:?}", tree);
+            let parents = unsafe {
+                std::slice::from_raw_parts((*tree.tree.as_ptr()).parent as *const NodeId, 4_usize)
+            };
+            println!("{:?}", parents);
         }
 
         // This is a safety sticking point:

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -70,6 +70,7 @@ impl TreeIterator {
 }
 
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct NonOwningTree {
     api: TreeInterface,
 }
@@ -90,9 +91,7 @@ impl NonOwningTree {
         flags: TreeFlags,
     ) -> Self {
         let api = TreeInterface::new(tree, num_nodes, array_len, flags);
-        Self {
-            api,
-        }
+        Self { api }
     }
 }
 

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -43,6 +43,16 @@ pub struct TreeIterator {
     flags: TreeFlags,
 }
 
+impl FromIterator<NonOwningTree> for Vec<Tree> {
+    fn from_iter<T: IntoIterator<Item = NonOwningTree>>(iter: T) -> Self {
+        let mut out = vec![];
+        for i in iter {
+            unimplemented!("not yet!");
+        }
+        out
+    }
+}
+
 impl TreeIterator {
     // FIXME: init if fallible!
     fn new(treeseq: &TreeSequence) -> Self {
@@ -772,10 +782,9 @@ pub(crate) mod test_trees {
         // This is a safety sticking point:
         // we cannot collect the iterable itself b/c
         // the underlying tree memory is re-used.
-        let v = treeseq
-            .trees()
-            .map(|t| t.as_owned()) // this is what we mean, but this is broken
-            .collect::<Vec<NonOwningTree>>();
+        let i = treeseq
+            .trees();
+        let v = Vec::<Tree>::from_iter(i);
         assert_eq!(v.len(), 2);
     }
 

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -770,9 +770,17 @@ pub(crate) mod test_trees {
         // This is a safety sticking point:
         // we cannot collect the iterable itself b/c
         // the underlying tree memory is re-used.
-        // let i = treeseq.trees();
-        // let v = Vec::<Tree>::from_iter(i);
-        // assert_eq!(v.len(), 2);
+        let i = treeseq.trees();
+        let v = Vec::<_>::from_iter(i);
+        assert_eq!(v.len(), 2);
+        for i in v {
+            println!("{:?}", i.parent_array());
+        }
+
+        let v = treeseq.trees().collect::<Vec<_>>();
+        for i in v {
+            println!("{:?}", i.parent_array());
+        }
     }
 
     #[should_panic]

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -46,6 +46,10 @@ impl FromIterator<NonOwningTree> for Vec<Tree> {
     fn from_iter<T: IntoIterator<Item = NonOwningTree>>(iter: T) -> Self {
         let mut out = vec![];
         for i in iter {
+            let mut lltree = MaybeUninit::<ll_bindings::tsk_tree_t>::uninit();
+            // NOTE: the following is fallible, but this function is not meant to be
+            let rv = unsafe { ll_bindings::tsk_tree_copy(i.tree.as_ptr(), lltree.as_mut_ptr(), 0) };
+            assert_eq!(rv, 0);
             unimplemented!("not yet!");
         }
         out

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -1,4 +1,5 @@
 use std::mem::MaybeUninit;
+use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
 use crate::bindings as ll_bindings;
@@ -782,8 +783,7 @@ pub(crate) mod test_trees {
         // This is a safety sticking point:
         // we cannot collect the iterable itself b/c
         // the underlying tree memory is re-used.
-        let i = treeseq
-            .trees();
+        let i = treeseq.trees();
         let v = Vec::<Tree>::from_iter(i);
         assert_eq!(v.len(), 2);
     }


### PR DESCRIPTION
This PR implements a "natural" iterator over trees:

* New type for which we `impl Iterator`.
* New function `TreeSequence::trees` returning the iterator.
