### PR TITLE
feat: impl Send/Sync for TreeSequence

### DIFF
--- a/src/trees.rs
+++ b/src/trees.rs
@@ -961,6 +961,9 @@ pub struct TreeSequence {
     pub(crate) inner: MBox<ll_bindings::tsk_treeseq_t>,
 }
 
+unsafe impl Send for TreeSequence {}
+unsafe impl Sync for TreeSequence {}
+
 build_tskit_type!(TreeSequence, ll_bindings::tsk_treeseq_t, tsk_treeseq_free);
 
 impl TreeSequence {
@@ -1610,5 +1613,21 @@ pub(crate) mod test_trees {
         } else {
             panic!("Expected a tree.");
         }
+    }
+}
+
+#[cfg(test)]
+mod test_treeeseq_send_sync {
+    use crate::test_fixtures::treeseq_from_small_table_collection_two_trees;
+    use std::sync::Arc;
+    use std::thread;
+
+    #[test]
+    fn build_arc() {
+        let t = treeseq_from_small_table_collection_two_trees();
+        let a = Arc::new(t);
+        let join_handle = thread::spawn(move || a.num_trees());
+        let ntrees = join_handle.join().unwrap();
+        assert_eq!(ntrees, 2);
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: implementing a new trait
will break code assuming that the type
is not thread save (!Sync + !Send).
