### PR TITLE
refactor: Display for new types now omits type name.

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -281,8 +281,8 @@ macro_rules! impl_id_traits {
         impl std::fmt::Display for $idtype {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 match *self == Self::NULL {
-                    false => write!(f, "{}({})", stringify!($idtype), self.0),
-                    true => write!(f, "{}(NULL)", stringify!($idtype)),
+                    false => write!(f, "{}", self.0),
+                    true => write!(f, "NULL"),
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,9 +158,12 @@ use bindings::tsk_size_t;
 /// use tskit::NodeId;
 ///
 /// let n = NodeId::from(11);
-/// assert_eq!(format!("{}", n), "NodeId(11)".to_string());
+/// assert_eq!(format!("{}", n), "11".to_string());
+/// // Debug output contains type info
+/// assert_eq!(format!("{:?}", n), "NodeId(11)".to_string());
 /// let n = NodeId::from(NodeId::NULL);
-/// assert_eq!(format!("{}", n), "NodeId(NULL)".to_string());
+/// assert_eq!(format!("{}", n), "NULL");
+/// assert_eq!(format!("{:?}", n), "NodeId(-1)");
 /// ```
 ///
 #[repr(transparent)]


### PR DESCRIPTION
BREAKING CHANGE: will break code that relies on the
type info being present in non-debug output.
