### PR TITLE
refactor: panics compatible with earlier rustc

### DIFF
--- a/src/tree_interface.rs
+++ b/src/tree_interface.rs
@@ -390,7 +390,7 @@ impl TreeInterface {
         for i in 0..num_samples {
             let u = match isize::try_from(i) {
                 Ok(o) => unsafe { *(*(*self.as_ptr()).tree_sequence).samples.offset(o) },
-                Err(e) => panic!("{e}"),
+                Err(e) => panic!("{}", e),
             };
             rv.push(u.into());
         }

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -356,7 +356,7 @@ impl TreeSequence {
         for i in 0..num_samples {
             let u = match isize::try_from(i) {
                 Ok(o) => NodeId::from(unsafe { *(*self.as_ptr()).samples.offset(o) }),
-                Err(e) => panic!("{e}"),
+                Err(e) => panic!("{}", e),
             };
             rv.push(u);
         }


### PR DESCRIPTION
Change 2 panic statements to be compatible with earlier rustc
versions.
