### PR TITLE
Return None for invalid row indexes

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -142,18 +142,13 @@ macro_rules! metadata_to_vector {
 
 macro_rules! decode_metadata_row {
     ($T: ty, $buffer: expr) => {
-        match $buffer {
-            None => Ok(None),
-            Some(v) => Ok(Some(<$T as $crate::metadata::MetadataRoundtrip>::decode(
-                &v,
-            )?)),
-        }
+        <$T as $crate::metadata::MetadataRoundtrip>::decode($buffer)
     };
 }
 
 macro_rules! table_row_decode_metadata {
     ($owner: ident, $table: ident, $pos: ident) => {
-        metadata_to_vector!($owner, $table, $pos).ok()?.map(|x| x)
+        metadata_to_vector!($owner, $table, $pos)
     };
 }
 

--- a/src/edge_table.rs
+++ b/src/edge_table.rs
@@ -130,10 +130,10 @@ impl<'a> EdgeTable<'a> {
     pub fn metadata<T: metadata::MetadataRoundtrip>(
         &'a self,
         row: EdgeId,
-    ) -> Result<Option<T>, TskitError> {
+    ) -> Option<Result<T, TskitError>> {
         let table_ref = self.table_;
         let buffer = metadata_to_vector!(self, table_ref, row.0)?;
-        decode_metadata_row!(T, buffer)
+        Some(decode_metadata_row!(T, buffer).map_err(|e| e.into()))
     }
 
     /// Return an iterator over rows of the table.
@@ -200,12 +200,13 @@ build_owned_table_type!(
     /// let rowid = edges.add_row_with_metadata(0., 1., 5, 10, &metadata).unwrap();
     /// assert_eq!(rowid, 0);
     ///
-    /// if let Some(decoded) = edges.metadata::<EdgeMetadata>(rowid).unwrap() {
-    ///     assert_eq!(decoded.value, 42);
-    /// } else {
-    ///     panic!("hmm...we expected some metadata!");
+    /// match edges.metadata::<EdgeMetadata>(rowid) {
+    ///     // rowid is in range, decoding succeeded
+    ///     Some(Ok(decoded)) => assert_eq!(decoded.value, 42),
+    ///     // rowid is in range, decoding failed
+    ///     Some(Err(e)) => panic!("error decoding metadata: {:?}", e),
+    ///     None => panic!("row id out of range")
     /// }
-    ///
     /// # }
     /// ```
     => OwnedEdgeTable,

--- a/tests/experimental.rs
+++ b/tests/experimental.rs
@@ -12,7 +12,7 @@ mod experimental_features {
     // * So hopefully we can start there.
     trait MetadataRetrieval<R> {
         type Metadata: tskit::metadata::MetadataRoundtrip;
-        fn metadata(&self, r: impl Into<R>) -> Result<Option<Self::Metadata>, tskit::TskitError>;
+        fn metadata(&self, r: impl Into<R>) -> Option<Result<Self::Metadata, tskit::TskitError>>;
     }
 
     // Specific traits cover the various row id types
@@ -20,9 +20,8 @@ mod experimental_features {
         fn mutation_metadata(
             &self,
             row: impl Into<tskit::MutationId>,
-        ) -> Result<
-            Option<<Self as MetadataRetrieval<tskit::MutationId>>::Metadata>,
-            tskit::TskitError,
+        ) -> Option<
+            Result<<Self as MetadataRetrieval<tskit::MutationId>>::Metadata, tskit::TskitError>,
         >
         where
             <Self as MetadataRetrieval<tskit::MutationId>>::Metadata:
@@ -39,9 +38,8 @@ mod experimental_features {
         fn mutation_metadata(
             &self,
             row: impl Into<tskit::MutationId>,
-        ) -> Result<
-            Option<<Self as MetadataRetrieval<tskit::MutationId>>::Metadata>,
-            tskit::TskitError,
+        ) -> Option<
+            Result<<Self as MetadataRetrieval<tskit::MutationId>>::Metadata, tskit::TskitError>,
         > {
             self.metadata(row)
         }
@@ -51,9 +49,8 @@ mod experimental_features {
         fn individual_metadata(
             &self,
             row: impl Into<tskit::IndividualId>,
-        ) -> Result<
-            Option<<Self as MetadataRetrieval<tskit::IndividualId>>::Metadata>,
-            tskit::TskitError,
+        ) -> Option<
+            Result<<Self as MetadataRetrieval<tskit::IndividualId>>::Metadata, tskit::TskitError>,
         >
         where
             <Self as MetadataRetrieval<tskit::IndividualId>>::Metadata:
@@ -69,9 +66,8 @@ mod experimental_features {
         fn individual_metadata(
             &self,
             row: impl Into<tskit::IndividualId>,
-        ) -> Result<
-            Option<<Self as MetadataRetrieval<tskit::IndividualId>>::Metadata>,
-            tskit::TskitError,
+        ) -> Option<
+            Result<<Self as MetadataRetrieval<tskit::IndividualId>>::Metadata, tskit::TskitError>,
         > {
             self.metadata(row)
         }
@@ -86,7 +82,7 @@ mod experimental_features {
         fn get_mutation_metadata<M: Into<tskit::MutationId>>(
             &self,
             row: M,
-        ) -> Result<Option<Self::Item>, tskit::TskitError>;
+        ) -> Option<Result<Self::Item, tskit::TskitError>>;
     }
 
     #[derive(serde::Serialize, serde::Deserialize, tskit::metadata::MutationMetadata)]
@@ -132,7 +128,7 @@ mod experimental_features {
         fn get_mutation_metadata<M: Into<tskit::MutationId>>(
             &self,
             row: M,
-        ) -> Result<Option<Self::Item>, tskit::TskitError> {
+        ) -> Option<Result<Self::Item, tskit::TskitError>> {
             self.mutations().metadata::<Self::Item>(row.into())
         }
     }
@@ -142,7 +138,7 @@ mod experimental_features {
         fn metadata(
             &self,
             row: impl Into<tskit::MutationId>,
-        ) -> Result<Option<MutationMetadataType>, tskit::TskitError> {
+        ) -> Option<Result<MutationMetadataType, tskit::TskitError>> {
             self.mutations()
                 .metadata::<MutationMetadataType>(row.into())
         }
@@ -153,7 +149,7 @@ mod experimental_features {
         fn metadata(
             &self,
             row: impl Into<tskit::IndividualId>,
-        ) -> Result<Option<IndividualMetadataType>, tskit::TskitError> {
+        ) -> Option<Result<IndividualMetadataType, tskit::TskitError>> {
             self.individuals()
                 .metadata::<IndividualMetadataType>(row.into())
         }
@@ -241,7 +237,7 @@ mod experimental_features_refined {
         fn get_mutation_metadata<M: Into<tskit::MutationId>>(
             &self,
             row: M,
-        ) -> Result<Option<Self::Item>, tskit::TskitError> {
+        ) -> Option<Result<Self::Item, tskit::TskitError>> {
             self.as_tables()
                 .mutations()
                 .metadata::<Self::Item>(row.into())


### PR DESCRIPTION
For metadata, site ancestral, mutation derived states:

* Return None when row index is out of range.
* This changes return types:
  * removes Result from ancestral/derived
  * Swaps result/option for metadata

Cannot merge until we validate the new
versions of "make a table row".
It seems that we have a testing gap here.

Closes #327
