### PR TITLE
anyhow compatability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tskit-derive = {version = "0.2.0", path = "tskit-derive", optional = true}
 mbox = "0.6.0"
 
 [dev-dependencies]
+anyhow = {version = "1.0.66"}
 clap = {version = "~3.2.8", features = ["derive"]}
 serde = {version = "1.0.118", features = ["derive"]}
 serde-pickle = "1.1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,4 +142,14 @@ mod test {
             panic!();
         }
     }
+
+    #[test]
+    fn test_anyhow_compatability() {
+        fn foo() -> anyhow::Result<crate::TableCollection> {
+            let tables = crate::TableCollection::new(1.0)?;
+            Ok(tables)
+        }
+
+        let _ = foo().unwrap();
+    }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -246,7 +246,7 @@ pub enum MetadataError {
     #[error("{}", *value)]
     RoundtripError {
         #[from]
-        value: Box<dyn std::error::Error>,
+        value: Box<dyn std::error::Error + Send + Sync>,
     },
 }
 


### PR DESCRIPTION
Make TskitError compatible with anyhow::Result.

Fixes #395
