### PR TITLE
refactor: remove TskitTypeAccess trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,7 +439,6 @@ pub use site_table::{OwningSiteTable, SiteTable, SiteTableRow};
 pub use table_collection::TableCollection;
 pub use traits::IndividualLocation;
 pub use traits::IndividualParents;
-pub use traits::TskitTypeAccess;
 pub use tree_interface::{NodeTraversalOrder, TreeInterface};
 pub use trees::{Tree, TreeSequence};
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,6 @@
 //! Export commonly-use types and traits
 
 pub use crate::tsk_flags_t;
-pub use crate::TskitTypeAccess;
 pub use crate::TSK_NODE_IS_SAMPLE;
 pub use streaming_iterator::DoubleEndedStreamingIterator;
 pub use streaming_iterator::StreamingIterator;

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -14,7 +14,6 @@ use crate::TableOutputOptions;
 use crate::TableSortOptions;
 use crate::TreeSequenceFlags;
 use crate::TskReturnValue;
-use crate::TskitTypeAccess;
 use crate::{tsk_id_t, tsk_size_t};
 use crate::{EdgeId, NodeId};
 use ll_bindings::tsk_table_collection_free;
@@ -57,16 +56,6 @@ pub struct TableCollection {
     inner: MBox<ll_bindings::tsk_table_collection_t>,
     idmap: Vec<NodeId>,
     views: crate::table_views::TableViews,
-}
-
-impl TskitTypeAccess<ll_bindings::tsk_table_collection_t> for TableCollection {
-    fn as_ptr(&self) -> *const ll_bindings::tsk_table_collection_t {
-        &*self.inner
-    }
-
-    fn as_mut_ptr(&mut self) -> *mut ll_bindings::tsk_table_collection_t {
-        &mut *self.inner
-    }
 }
 
 impl Drop for TableCollection {
@@ -1229,4 +1218,14 @@ impl TableCollection {
     }
 
     delegate_table_view_api!();
+
+    /// Pointer to the low-level C type.
+    pub fn as_ptr(&self) -> *const ll_bindings::tsk_table_collection_t {
+        &*self.inner
+    }
+
+    /// Mutable pointer to the low-level C type.
+    pub fn as_mut_ptr(&mut self) -> *mut ll_bindings::tsk_table_collection_t {
+        &mut *self.inner
+    }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,13 +1,5 @@
 //! Traits related to user-facing types
 
-/// Provide pointer access to underlying C types
-pub trait TskitTypeAccess<T> {
-    /// Return const pointer
-    fn as_ptr(&self) -> *const T;
-    /// Return mutable pointer
-    fn as_mut_ptr(&mut self) -> *mut T;
-}
-
 /// Abstraction of individual location.
 ///
 /// This trait exists to streamline the API of

--- a/src/tree_interface.rs
+++ b/src/tree_interface.rs
@@ -7,7 +7,6 @@ use crate::SizeType;
 use crate::Time;
 use crate::TreeFlags;
 use crate::TskitError;
-use crate::TskitTypeAccess;
 use std::ptr::NonNull;
 
 pub struct TreeInterface {
@@ -15,16 +14,6 @@ pub struct TreeInterface {
     num_nodes: tsk_size_t,
     array_len: tsk_size_t,
     flags: TreeFlags,
-}
-
-impl TskitTypeAccess<ll_bindings::tsk_tree_t> for TreeInterface {
-    fn as_ptr(&self) -> *const ll_bindings::tsk_tree_t {
-        self.non_owned_pointer.as_ptr()
-    }
-
-    fn as_mut_ptr(&mut self) -> *mut ll_bindings::tsk_tree_t {
-        self.non_owned_pointer.as_ptr()
-    }
 }
 
 impl TreeInterface {
@@ -40,6 +29,16 @@ impl TreeInterface {
             array_len,
             flags,
         }
+    }
+
+    /// Pointer to the low-level C type.
+    pub fn as_ptr(&self) -> *const ll_bindings::tsk_tree_t {
+        self.non_owned_pointer.as_ptr()
+    }
+
+    /// Mutable pointer to the low-level C type.
+    pub fn as_mut_ptr(&mut self) -> *mut ll_bindings::tsk_tree_t {
+        self.non_owned_pointer.as_ptr()
     }
 
     pub fn flags(&self) -> TreeFlags {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -12,7 +12,6 @@ use crate::TreeFlags;
 use crate::TreeInterface;
 use crate::TreeSequenceFlags;
 use crate::TskReturnValue;
-use crate::TskitTypeAccess;
 use crate::{tsk_id_t, tsk_size_t, TableCollection};
 use ll_bindings::tsk_tree_free;
 use std::ptr::NonNull;
@@ -192,16 +191,6 @@ pub struct TreeSequence {
 unsafe impl Send for TreeSequence {}
 unsafe impl Sync for TreeSequence {}
 
-impl TskitTypeAccess<ll_bindings::tsk_treeseq_t> for TreeSequence {
-    fn as_ptr(&self) -> *const ll_bindings::tsk_treeseq_t {
-        &self.inner
-    }
-
-    fn as_mut_ptr(&mut self) -> *mut ll_bindings::tsk_treeseq_t {
-        &mut self.inner
-    }
-}
-
 impl Drop for TreeSequence {
     fn drop(&mut self) {
         let rv = unsafe { ll_bindings::tsk_treeseq_free(&mut self.inner) };
@@ -268,6 +257,16 @@ impl TreeSequence {
             let inner = unsafe { inner.assume_init() };
             Self { inner, views }
         })
+    }
+
+    /// Pointer to the low-level C type.
+    pub fn as_ptr(&self) -> *const ll_bindings::tsk_treeseq_t {
+        &self.inner
+    }
+
+    /// Mutable pointer to the low-level C type.
+    pub fn as_mut_ptr(&mut self) -> *mut ll_bindings::tsk_treeseq_t {
+        &mut self.inner
     }
 
     /// Dump the tree sequence to file.


### PR DESCRIPTION
The trait has been replaced with pub fns for all types.
The trait was not a great idea as it made no sense
to be generic over access to the low-level pointers.

BREAKING CHANGE: removed a pub trait.
