### PR TITLE
refactor: Allow TreeSequence::edge_differences_iter to Err.

### DIFF
--- a/src/edge_differences.rs
+++ b/src/edge_differences.rs
@@ -28,12 +28,14 @@ impl Drop for LLEdgeDifferenceIterator {
 }
 
 impl LLEdgeDifferenceIterator {
-    pub fn new_from_treeseq(treeseq: &TreeSequence, flags: bindings::tsk_flags_t) -> Option<Self> {
+    pub fn new_from_treeseq(
+        treeseq: &TreeSequence,
+        flags: bindings::tsk_flags_t,
+    ) -> Result<Self, crate::TskitError> {
         let mut inner = std::mem::MaybeUninit::<bindings::tsk_diff_iter_t>::uninit();
-        match unsafe { bindings::tsk_diff_iter_init(inner.as_mut_ptr(), treeseq.as_ptr(), flags) } {
-            x if x < 0 => None,
-            _ => Some(Self(unsafe { inner.assume_init() })),
-        }
+        let code =
+            unsafe { bindings::tsk_diff_iter_init(inner.as_mut_ptr(), treeseq.as_ptr(), flags) };
+        handle_tsk_return_value!(code, Self(unsafe { inner.assume_init() }))
     }
 }
 
@@ -191,7 +193,7 @@ impl EdgeDifferencesIterator {
     pub(crate) fn new_from_treeseq(
         treeseq: &TreeSequence,
         flags: bindings::tsk_flags_t,
-    ) -> Option<Self> {
+    ) -> Result<Self, crate::TskitError> {
         LLEdgeDifferenceIterator::new_from_treeseq(treeseq, flags).map(|inner| Self {
             inner,
             insertion: LLEdgeInsertionList::default(),

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -541,14 +541,13 @@ impl TreeSequence {
 
     /// Build a lending iterator over edge differences.
     ///
-    /// # Returns
+    /// # Errors
     ///
-    /// * None if the `C` back end is unable to allocate
+    /// * [`TskitError`] if the `C` back end is unable to allocate
     ///   needed memory
-    /// * `Some(iterator)` otherwise.
     pub fn edge_differences_iter(
         &self,
-    ) -> Option<crate::edge_differences::EdgeDifferencesIterator> {
+    ) -> Result<crate::edge_differences::EdgeDifferencesIterator, TskitError> {
         crate::edge_differences::EdgeDifferencesIterator::new_from_treeseq(self, 0)
     }
 }
@@ -883,7 +882,7 @@ pub(crate) mod test_trees {
             let treeseq = treeseq_from_small_table_collection_two_trees();
             let num_nodes: usize = treeseq.nodes().num_rows().try_into().unwrap();
             let mut parents = vec![NodeId::NULL; num_nodes + 1];
-            if let Some(mut ediff_iter) = treeseq.edge_differences_iter() {
+            if let Ok(mut ediff_iter) = treeseq.edge_differences_iter() {
                 let mut tree_iter = treeseq.tree_iterator(0).unwrap();
                 let mut ntrees = 0;
                 while let Some(diffs) = ediff_iter.next() {


### PR DESCRIPTION
Allows reporting of OOM conditions from back end.
