### PR TITLE
Generic fn for ragged column access

### DIFF
--- a/src/edge_table.rs
+++ b/src/edge_table.rs
@@ -31,14 +31,13 @@ impl PartialEq for EdgeTableRow {
 }
 
 fn make_edge_table_row(table: &EdgeTable, pos: tsk_id_t) -> Option<EdgeTableRow> {
-    let table_ref = table.as_ref();
     Some(EdgeTableRow {
         id: pos.into(),
         left: table.left(pos)?,
         right: table.right(pos)?,
         parent: table.parent(pos)?,
         child: table.child(pos)?,
-        metadata: table_row_decode_metadata!(table, table_ref, pos).map(|m| m.to_vec()),
+        metadata: table.raw_metadata(pos.into()).map(|m| m.to_vec()),
     })
 }
 
@@ -238,8 +237,7 @@ impl EdgeTable {
         &self,
         row: EdgeId,
     ) -> Option<Result<T, TskitError>> {
-        let table_ref = self.as_ref();
-        let buffer = metadata_to_vector!(self, table_ref, row.into())?;
+        let buffer = self.raw_metadata(row)?;
         Some(decode_metadata_row!(T, buffer).map_err(|e| e.into()))
     }
 

--- a/src/migration_table.rs
+++ b/src/migration_table.rs
@@ -37,7 +37,6 @@ impl PartialEq for MigrationTableRow {
 }
 
 fn make_migration_table_row(table: &MigrationTable, pos: tsk_id_t) -> Option<MigrationTableRow> {
-    let table_ref = table.as_ref();
     Some(MigrationTableRow {
         id: pos.into(),
         left: table.left(pos)?,
@@ -46,7 +45,7 @@ fn make_migration_table_row(table: &MigrationTable, pos: tsk_id_t) -> Option<Mig
         source: table.source(pos)?,
         dest: table.dest(pos)?,
         time: table.time(pos)?,
-        metadata: table_row_decode_metadata!(table, table_ref, pos).map(|m| m.to_vec()),
+        metadata: table.raw_metadata(pos.into()).map(|m| m.to_vec()),
     })
 }
 
@@ -285,8 +284,7 @@ impl MigrationTable {
         &self,
         row: MigrationId,
     ) -> Option<Result<T, TskitError>> {
-        let table_ref = self.as_ref();
-        let buffer = metadata_to_vector!(self, table_ref, row.into())?;
+        let buffer = self.raw_metadata(row)?;
         Some(decode_metadata_row!(T, buffer).map_err(|e| e.into()))
     }
 

--- a/src/node_table.rs
+++ b/src/node_table.rs
@@ -33,14 +33,13 @@ impl PartialEq for NodeTableRow {
 }
 
 fn make_node_table_row(table: &NodeTable, pos: tsk_id_t) -> Option<NodeTableRow> {
-    let table_ref = table.as_ref();
     Some(NodeTableRow {
         id: pos.into(),
         time: table.time(pos)?,
         flags: table.flags(pos)?,
         population: table.population(pos)?,
         individual: table.individual(pos)?,
-        metadata: table_row_decode_metadata!(table, table_ref, pos).map(|m| m.to_vec()),
+        metadata: table.raw_metadata(pos.into()).map(|m| m.to_vec()),
     })
 }
 
@@ -340,8 +339,7 @@ impl NodeTable {
         &self,
         row: NodeId,
     ) -> Option<Result<T, TskitError>> {
-        let table_ref = self.as_ref();
-        let buffer = metadata_to_vector!(self, table_ref, row.into())?;
+        let buffer = self.raw_metadata(row)?;
         Some(decode_metadata_row!(T, buffer).map_err(|e| e.into()))
     }
 

--- a/src/population_table.rs
+++ b/src/population_table.rs
@@ -22,12 +22,11 @@ impl PartialEq for PopulationTableRow {
 }
 
 fn make_population_table_row(table: &PopulationTable, pos: tsk_id_t) -> Option<PopulationTableRow> {
-    let table_ref = table.as_ref();
     let index = ll_bindings::tsk_size_t::try_from(pos).ok()?;
 
     match index {
         i if i < table.num_rows() => {
-            let metadata = table_row_decode_metadata!(table, table_ref, pos).map(|s| s.to_vec());
+            let metadata = table.raw_metadata(pos.into()).map(|m| m.to_vec());
             Some(PopulationTableRow {
                 id: pos.into(),
                 metadata,
@@ -162,8 +161,7 @@ impl PopulationTable {
         &self,
         row: PopulationId,
     ) -> Option<Result<T, TskitError>> {
-        let table_ref = self.as_ref();
-        let buffer = metadata_to_vector!(self, table_ref, row.into())?;
+        let buffer = self.raw_metadata(row)?;
         Some(decode_metadata_row!(T, buffer).map_err(TskitError::from))
     }
 

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -13,6 +13,7 @@
 use std::ptr::NonNull;
 
 use crate::bindings as ll_bindings;
+use crate::sys;
 use crate::SizeType;
 use crate::{tsk_id_t, tsk_size_t, ProvenanceId};
 use ll_bindings::{tsk_provenance_table_free, tsk_provenance_table_init};
@@ -185,14 +186,12 @@ impl ProvenanceTable {
     /// # }
     /// ```
     pub fn timestamp<P: Into<ProvenanceId> + Copy>(&self, row: P) -> Option<&str> {
-        let timestamp_slice = unsafe_tsk_ragged_char_column_access_to_slice_u8!(
+        let timestamp_slice = sys::tsk_ragged_column_access(
             row.into(),
-            0,
+            self.as_ref().timestamp,
             self.num_rows(),
-            self.as_ref(),
-            timestamp,
-            timestamp_offset,
-            timestamp_length
+            self.as_ref().timestamp_offset,
+            self.as_ref().timestamp_length,
         );
         match timestamp_slice {
             Some(tstamp) => std::str::from_utf8(tstamp).ok(),
@@ -221,14 +220,12 @@ impl ProvenanceTable {
     /// # panic!("Expected Some(timestamp)");
     /// # }
     pub fn record<P: Into<ProvenanceId> + Copy>(&self, row: P) -> Option<&str> {
-        let record_slice = unsafe_tsk_ragged_char_column_access_to_slice_u8!(
+        let record_slice = sys::tsk_ragged_column_access(
             row.into(),
-            0,
+            self.as_ref().record,
             self.num_rows(),
-            self.as_ref(),
-            record,
-            record_offset,
-            record_length
+            self.as_ref().record_offset,
+            self.as_ref().record_length,
         );
         match record_slice {
             Some(rec) => std::str::from_utf8(rec).ok(),

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -30,3 +30,59 @@ pub fn tsk_column_access<
 ) -> Option<O> {
     tsk_column_access_detail(row, column, column_length).map(|v| v.into())
 }
+
+fn tsk_ragged_column_access_detail<
+    R: Into<bindings::tsk_id_t>,
+    L: Into<bindings::tsk_size_t>,
+    T: Copy,
+>(
+    row: R,
+    column: *const T,
+    column_length: L,
+    offset: *const bindings::tsk_size_t,
+    offset_length: bindings::tsk_size_t,
+) -> Option<(*const T, usize)> {
+    let row = row.into();
+    let column_length = column_length.into();
+    if row < 0 || row as bindings::tsk_size_t > column_length || offset_length == 0 {
+        None
+    } else {
+        assert!(!column.is_null());
+        assert!(!offset.is_null());
+        // SAFETY: pointers are not null
+        // and *_length are given by tskit-c
+        let index = row as isize;
+        let start = unsafe { *offset.offset(index) };
+        let stop = if (row as bindings::tsk_size_t) < column_length {
+            unsafe { *offset.offset(index + 1) }
+        } else {
+            offset_length
+        };
+        if start == stop {
+            None
+        } else {
+            Some((
+                unsafe { column.offset(start as isize) },
+                stop as usize - start as usize,
+            ))
+        }
+    }
+}
+
+pub fn tsk_ragged_column_access<
+    'a,
+    O,
+    R: Into<bindings::tsk_id_t>,
+    L: Into<bindings::tsk_size_t>,
+    T: Copy,
+>(
+    row: R,
+    column: *const T,
+    column_length: L,
+    offset: *const bindings::tsk_size_t,
+    offset_length: bindings::tsk_size_t,
+) -> Option<&'a [O]> {
+    // SAFETY: see tsk_ragged_column_access_detail
+    tsk_ragged_column_access_detail(row, column, column_length, offset, offset_length)
+        .map(|(p, n)| unsafe { std::slice::from_raw_parts(p.cast::<O>(), n) })
+}


### PR DESCRIPTION
Replace macros with generic for accessing ragged columns.
This improves readability and is starting to shrink the library.
