### PR TITLE
refactor: raw_metadata fn for tables now takes Into<row id>.

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -965,7 +965,7 @@ macro_rules! build_owned_table_type {
 
 macro_rules! raw_metadata_getter_for_tables {
     ($idtype: ty) => {
-        fn raw_metadata(&self, row: $idtype) -> Option<&[u8]> {
+        fn raw_metadata<I: Into<$idtype>>(&self, row: I) -> Option<&[u8]> {
             $crate::sys::tsk_ragged_column_access::<'_, u8, $idtype, _, _>(
                 row.into(),
                 self.as_ref().metadata,

--- a/src/edge_table.rs
+++ b/src/edge_table.rs
@@ -37,7 +37,7 @@ fn make_edge_table_row(table: &EdgeTable, pos: tsk_id_t) -> Option<EdgeTableRow>
         right: table.right(pos)?,
         parent: table.parent(pos)?,
         child: table.child(pos)?,
-        metadata: table.raw_metadata(pos.into()).map(|m| m.to_vec()),
+        metadata: table.raw_metadata(pos).map(|m| m.to_vec()),
     })
 }
 

--- a/src/individual_table.rs
+++ b/src/individual_table.rs
@@ -114,7 +114,7 @@ fn make_individual_table_row(table: &IndividualTable, pos: tsk_id_t) -> Option<I
         flags: table.flags(pos)?,
         location: table.location(pos).map(|s| s.to_vec()),
         parents: table.parents(pos).map(|s| s.to_vec()),
-        metadata: table.raw_metadata(pos.into()).map(|m| m.to_vec()),
+        metadata: table.raw_metadata(pos).map(|m| m.to_vec()),
     })
 }
 

--- a/src/migration_table.rs
+++ b/src/migration_table.rs
@@ -45,7 +45,7 @@ fn make_migration_table_row(table: &MigrationTable, pos: tsk_id_t) -> Option<Mig
         source: table.source(pos)?,
         dest: table.dest(pos)?,
         time: table.time(pos)?,
-        metadata: table.raw_metadata(pos.into()).map(|m| m.to_vec()),
+        metadata: table.raw_metadata(pos).map(|m| m.to_vec()),
     })
 }
 

--- a/src/mutation_table.rs
+++ b/src/mutation_table.rs
@@ -45,7 +45,7 @@ fn make_mutation_table_row(table: &MutationTable, pos: tsk_id_t) -> Option<Mutat
                 parent: table.parent(pos)?,
                 time: table.time(pos)?,
                 derived_state,
-                metadata: table.raw_metadata(pos.into()).map(|m| m.to_vec()),
+                metadata: table.raw_metadata(pos).map(|m| m.to_vec()),
             })
         }
         _ => None,

--- a/src/node_table.rs
+++ b/src/node_table.rs
@@ -39,7 +39,7 @@ fn make_node_table_row(table: &NodeTable, pos: tsk_id_t) -> Option<NodeTableRow>
         flags: table.flags(pos)?,
         population: table.population(pos)?,
         individual: table.individual(pos)?,
-        metadata: table.raw_metadata(pos.into()).map(|m| m.to_vec()),
+        metadata: table.raw_metadata(pos).map(|m| m.to_vec()),
     })
 }
 

--- a/src/population_table.rs
+++ b/src/population_table.rs
@@ -26,7 +26,7 @@ fn make_population_table_row(table: &PopulationTable, pos: tsk_id_t) -> Option<P
 
     match index {
         i if i < table.num_rows() => {
-            let metadata = table.raw_metadata(pos.into()).map(|m| m.to_vec());
+            let metadata = table.raw_metadata(pos).map(|m| m.to_vec());
             Some(PopulationTableRow {
                 id: pos.into(),
                 metadata,

--- a/src/site_table.rs
+++ b/src/site_table.rs
@@ -34,7 +34,7 @@ fn make_site_table_row(table: &SiteTable, pos: tsk_id_t) -> Option<SiteTableRow>
         id: pos.into(),
         position: table.position(pos)?,
         ancestral_state,
-        metadata: table.raw_metadata(pos.into()).map(|m| m.to_vec()),
+        metadata: table.raw_metadata(pos).map(|m| m.to_vec()),
     })
 }
 


### PR DESCRIPTION
This change improves ergonomics and makes the API
consistent with other getter fns.
