### PR TITLE
refactor: sys module no longer depends on TskitError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 //! Error handling
 
+use crate::sys;
 use crate::TskReturnValue;
 use thiserror::Error;
 
@@ -34,6 +35,15 @@ pub enum TskitError {
     /// General error variant
     #[error("{}", *.0)]
     LibraryError(String),
+}
+
+impl From<crate::sys::Error> for TskitError {
+    fn from(error: sys::Error) -> Self {
+        match error {
+            sys::Error::Message(msg) => TskitError::LibraryError(msg),
+            sys::Error::Code(code) => TskitError::ErrorCode { code },
+        }
+    }
 }
 
 /// Takes the return code from a tskit

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -282,7 +282,9 @@ impl TreeSequence {
         let c_str = std::ffi::CString::new(filename).map_err(|_| {
             TskitError::LibraryError("call to ffi::Cstring::new failed".to_string())
         })?;
-        self.inner.dump(c_str, options.into().bits())
+        self.inner
+            .dump(c_str, options.into().bits())
+            .map_err(|e| e.into())
     }
 
     /// Load from a file.
@@ -404,7 +406,9 @@ impl TreeSequence {
     /// * `lambda` specifies the relative weight of topology and branch length.
     ///    See [`TreeInterface::kc_distance`] for more details.
     pub fn kc_distance(&self, other: &TreeSequence, lambda: f64) -> Result<f64, TskitError> {
-        self.inner.kc_distance(&other.inner, lambda)
+        self.inner
+            .kc_distance(&other.inner, lambda)
+            .map_err(|e| e.into())
     }
 
     // FIXME: document


### PR DESCRIPTION
* sys now defines its own Error.
* impl From<sys::Error> for TskitError
