### PR TITLE
refactor: tidy up table definitions

### DIFF
--- a/src/edge_table.rs
+++ b/src/edge_table.rs
@@ -145,7 +145,7 @@ impl<'a> streaming_iterator::StreamingIterator for EdgeTableRowView<'a> {
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct EdgeTable {
-    pub(crate) table_: sys::LLEdgeTableRef,
+    table_: sys::LLEdgeTableRef,
 }
 
 impl EdgeTable {

--- a/src/individual_table.rs
+++ b/src/individual_table.rs
@@ -101,6 +101,7 @@ impl<'a> streaming_iterator::StreamingIterator for IndividualTableRowView<'a> {
 /// by types implementing [`std::ops::Deref`] to
 /// [`crate::table_views::TableViews`]
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct IndividualTable {
     table_: sys::LLIndividualTableRef,
 }

--- a/src/migration_table.rs
+++ b/src/migration_table.rs
@@ -163,6 +163,7 @@ impl<'a> streaming_iterator::StreamingIterator for MigrationTableRowView<'a> {
 /// by types implementing [`std::ops::Deref`] to
 /// [`crate::table_views::TableViews`]
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct MigrationTable {
     table_: sys::LLMigrationTableRef,
 }

--- a/src/mutation_table.rs
+++ b/src/mutation_table.rs
@@ -160,6 +160,7 @@ impl<'a> streaming_iterator::StreamingIterator for MutationTableRowView<'a> {
 /// by types implementing [`std::ops::Deref`] to
 /// [`crate::table_views::TableViews`]
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct MutationTable {
     table_: sys::LLMutationTableRef,
 }

--- a/src/node_table.rs
+++ b/src/node_table.rs
@@ -144,6 +144,7 @@ impl<'a> streaming_iterator::StreamingIterator for NodeTableRowView<'a> {
 /// by types implementing [`std::ops::Deref`] to
 /// [`crate::table_views::TableViews`]
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct NodeTable {
     table_: sys::LLNodeTableRef,
 }

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -137,6 +137,7 @@ impl<'a> streaming_iterator::StreamingIterator for ProvenanceTableRowView<'a> {
 /// * The type is enabled by the `"provenance"` feature.
 ///
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct ProvenanceTable {
     table_: sys::LLProvenanceTableRef,
 }

--- a/src/site_table.rs
+++ b/src/site_table.rs
@@ -130,6 +130,7 @@ impl<'a> streaming_iterator::StreamingIterator for SiteTableRowView<'a> {
 /// by types implementing [`std::ops::Deref`] to
 /// [`crate::table_views::TableViews`]
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct SiteTable {
     table_: sys::LLSiteTableRef,
 }

--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -109,7 +109,7 @@ impl TableCollection {
         // AHA?
         assert!(std::ptr::eq(
             &mbox.as_ref().edges as *const ll_bindings::tsk_edge_table_t,
-            views.edges().table_.as_ref() as *const ll_bindings::tsk_edge_table_t
+            views.edges().as_ref() as *const ll_bindings::tsk_edge_table_t
         ));
         let mut tables = Self {
             inner: mbox,


### PR DESCRIPTION
* All tables are now repr(transparent)
* Clean up internal field visibility issue for EdgeTable.
