### PR TITLE
NEVER MERGE: efficient tree indexing prototype

### DIFF
--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -91,13 +91,13 @@ fn main() {
         );
 
         let mut niterations = 0;
-        println!("{} {} {}", i,
+        println!("LEFT INDEX: {} {} {}", i,
                  unsafe { (*tree_at_lib.as_ptr()).left_index },
                  unsafe { (*tree_at.as_ptr()).left_index }
 
                  );
         while let Some(tree_at_lib) = tree_at_lib.next() {
-            //let tree_at = tree_at.next().unwrap();
+            let tree_at = tree_at.next().unwrap();
             //let tree_at_jk = tree_at_jk.next().unwrap();
 
             //assert_eq!(tree_at_lib.interval(), tree_at.interval());

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -92,10 +92,10 @@ fn main() {
 
         let mut niterations = 0;
         assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
-            (*tree_at.as_ptr()).left_index
+            (*tree_at_jk.as_ptr()).left_index
         });
         assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
-            (*tree_at.as_ptr()).right_index
+            (*tree_at_jk.as_ptr()).right_index
         });
         assert_eq!(unsafe { (*tree_at_lib.as_ptr()).num_edges }, unsafe {
             (*tree_at.as_ptr()).num_edges
@@ -134,6 +134,14 @@ fn main() {
                 "tree index = {}",
                 i
             );
+            //let ttime_lib: f64 = tree_at_lib.total_branch_length(false).unwrap().into();
+            //let ttime_jk: f64 = tree_at_jk.total_branch_length(false).unwrap().into();
+            //assert!(
+            //    (ttime_jk - ttime_lib).abs() <= 1e-6,
+            //    "{} {}",
+            //    ttime_lib,
+            //    ttime_jk
+            //);
             //compare(
             //    i,
             //    "parent",

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -108,21 +108,28 @@ fn main() {
         });
         while let Some(tree_at_lib) = tree_at_lib.next() {
             let tree_at = tree_at.next().unwrap();
-            let tree_at_jk = tree_at_jk.next().unwrap();
-
             assert_eq!(tree_at_lib.interval(), tree_at.interval());
-            assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
             assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {
                 (*tree_at.as_ptr()).index
-            });
-            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {
-                (*tree_at_jk.as_ptr()).index
             });
             assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
                 (*tree_at.as_ptr()).left_index
             });
             assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
                 (*tree_at.as_ptr()).right_index
+            });
+            compare(
+                i,
+                "parent",
+                tree_at.parent_array(),
+                tree_at_lib.parent_array(),
+            );
+
+            let tree_at_jk = tree_at_jk.next().unwrap();
+
+            assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
+            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {
+                (*tree_at_jk.as_ptr()).index
             });
             assert_eq!(unsafe { (*tree_at_lib.as_ptr()).num_edges }, unsafe {
                 (*tree_at_jk.as_ptr()).num_edges
@@ -136,7 +143,7 @@ fn main() {
             assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
             assert_eq!(
                 unsafe { (*tree_at_lib.as_ptr()).index },
-                unsafe { (*tree_at.as_ptr()).index },
+                unsafe { (*tree_at_jk.as_ptr()).index },
                 "tree index = {}",
                 i
             );
@@ -148,12 +155,6 @@ fn main() {
             //    ttime_lib,
             //    ttime_jk
             //);
-            compare(
-                i,
-                "parent",
-                tree_at.parent_array(),
-                tree_at_lib.parent_array(),
-            );
             compare(
                 i,
                 "parent jk",

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -116,23 +116,31 @@ fn main() {
             (*tree_at_jk.as_ptr()).num_edges
         });
         while let Some(tree_at_lib) = tree_at_lib.next() {
-            //let tree_at = tree_at.next().unwrap();
-            //assert_eq!(tree_at_lib.interval(), tree_at.interval());
-            //assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {
-            //    (*tree_at.as_ptr()).index
-            //});
+            let tree_at = tree_at.next().unwrap();
+            assert_eq!(tree_at_lib.interval(), tree_at.interval());
+            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {
+                (*tree_at.as_ptr()).index
+            });
             //assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
             //    (*tree_at.as_ptr()).left_index
             //});
             //assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
             //    (*tree_at.as_ptr()).right_index
             //});
-            //compare(
-            //    i,
-            //    "parent",
-            //    tree_at.parent_array(),
-            //    tree_at_lib.parent_array(),
-            //);
+            compare(
+                i,
+                "parent",
+                tree_at.parent_array(),
+                tree_at_lib.parent_array(),
+            );
+            let ttime_lib: f64 = tree_at_lib.total_branch_length(false).unwrap().into();
+            let ttime: f64 = tree_at.total_branch_length(false).unwrap().into();
+            assert!(
+                (ttime - ttime_lib).abs() <= 1e-6,
+                "{} {}",
+                ttime_lib,
+                ttime
+            );
 
             //println!("JK");
             let tree_at_jk = tree_at_jk.next().unwrap();

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -35,6 +35,7 @@ fn main() {
     let flags = tskit::TreeFlags::SAMPLE_LISTS;
     let indexes = tskit::TreesIndex::new(&treeseq).unwrap();
 
+    println!("method index time");
     for i in (0..num_trees).step_by(args.stepsize as usize) {
         assert!(i < num_trees);
         let now = Instant::now();
@@ -47,12 +48,8 @@ fn main() {
             .tree_iterator_at_index_lib(i.into(), &indexes, flags)
             .unwrap();
         let duration_lib = now.elapsed();
-        println!(
-            "{} {:?} {:?}",
-            i,
-            duration.as_micros(),
-            duration_lib.as_micros()
-        );
+        println!("indexes {:?} {:?}", i, duration.as_micros(),);
+        println!("lib {:?} {:?}", i, duration_lib.as_micros(),);
 
         compare(
             i,

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -91,17 +91,42 @@ fn main() {
         );
 
         let mut niterations = 0;
-        println!("LEFT INDEX: {} {} {}", i,
-                 unsafe { (*tree_at_lib.as_ptr()).left_index },
-                 unsafe { (*tree_at.as_ptr()).left_index }
-
-                 );
+        println!(
+            "LEFT INDEX: {} {} {}",
+            i,
+            unsafe { (*tree_at_lib.as_ptr()).left_index },
+            unsafe { (*tree_at.as_ptr()).left_index }
+        );
+        println!(
+            "RIGHT INDEX: {} {} {}",
+            i,
+            unsafe { (*tree_at_lib.as_ptr()).right_index },
+            unsafe { (*tree_at.as_ptr()).right_index }
+        );
         while let Some(tree_at_lib) = tree_at_lib.next() {
             let tree_at = tree_at.next().unwrap();
-            //let tree_at_jk = tree_at_jk.next().unwrap();
+            let tree_at_jk = tree_at_jk.next().unwrap();
 
-            //assert_eq!(tree_at_lib.interval(), tree_at.interval());
-            //assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
+            assert_eq!(tree_at_lib.interval(), tree_at.interval());
+            assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
+            assert_eq!(
+                unsafe { (*tree_at_lib.as_ptr()).index },
+                unsafe { (*tree_at.as_ptr()).index },
+                "tree index = {}",
+                i
+            );
+            compare(
+                i,
+                "parent",
+                tree_at.parent_array(),
+                tree_at_lib.parent_array(),
+            );
+            compare(
+                i,
+                "parent jk",
+                tree_at_jk.parent_array(),
+                tree_at_lib.parent_array(),
+            );
             niterations += 1;
         }
         println!("{}", niterations);

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -37,17 +37,17 @@ fn main() {
     for i in (0..num_trees).step_by(args.stepsize as usize) {
         assert!(i < num_trees);
         let now = Instant::now();
-        let tree_at = treeseq
+        let mut tree_at = treeseq
             .tree_iterator_at_index(i.into(), &indexes, flags)
             .unwrap();
         let duration = now.elapsed();
         let now = Instant::now();
-        let tree_at_lib = treeseq
+        let mut tree_at_lib = treeseq
             .tree_iterator_at_index_lib(i.into(), &indexes, flags)
             .unwrap();
         let duration_lib = now.elapsed();
         let now = Instant::now();
-        let tree_at_jk = treeseq
+        let mut tree_at_jk = treeseq
             .tree_iterator_at_index_jk(i.into(), &indexes, flags)
             .unwrap();
         let duration_jk = now.elapsed();
@@ -89,6 +89,22 @@ fn main() {
             tree_at_jk.parent_array(),
             tree_at_lib.parent_array(),
         );
+
+        let mut niterations = 0;
+        println!("{} {} {}", i,
+                 unsafe { (*tree_at_lib.as_ptr()).left_index },
+                 unsafe { (*tree_at.as_ptr()).left_index }
+
+                 );
+        while let Some(tree_at_lib) = tree_at_lib.next() {
+            //let tree_at = tree_at.next().unwrap();
+            //let tree_at_jk = tree_at_jk.next().unwrap();
+
+            //assert_eq!(tree_at_lib.interval(), tree_at.interval());
+            //assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
+            niterations += 1;
+        }
+        println!("{}", niterations);
 
         // The following may not be valid:
         // the different remove/insert ops

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -74,6 +74,9 @@ fn main() {
             ttime_lib
         );
 
+        assert_eq!(tree_at.interval(), tree_at_lib.interval());
+        assert_eq!(tree_at_jk.interval(), tree_at_lib.interval());
+
         compare(
             i,
             "parent",

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -91,18 +91,12 @@ fn main() {
         );
 
         let mut niterations = 0;
-        println!(
-            "LEFT INDEX: {} {} {}",
-            i,
-            unsafe { (*tree_at_lib.as_ptr()).left_index },
-            unsafe { (*tree_at.as_ptr()).left_index }
-        );
-        println!(
-            "RIGHT INDEX: {} {} {}",
-            i,
-            unsafe { (*tree_at_lib.as_ptr()).right_index },
-            unsafe { (*tree_at.as_ptr()).right_index }
-        );
+        assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
+            (*tree_at.as_ptr()).left_index
+        });
+        assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
+            (*tree_at.as_ptr()).right_index
+        });
         assert_eq!(unsafe { (*tree_at_lib.as_ptr()).num_edges }, unsafe {
             (*tree_at.as_ptr()).num_edges
         });
@@ -115,24 +109,43 @@ fn main() {
 
             assert_eq!(tree_at_lib.interval(), tree_at.interval());
             assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
+            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {
+                (*tree_at.as_ptr()).index
+            });
+            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {
+                (*tree_at_jk.as_ptr()).index
+            });
+            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
+                (*tree_at.as_ptr()).left_index
+            });
+            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
+                (*tree_at.as_ptr()).right_index
+            });
+            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
+                (*tree_at_jk.as_ptr()).left_index
+            });
+            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
+                (*tree_at_jk.as_ptr()).right_index
+            });
+            assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
             assert_eq!(
                 unsafe { (*tree_at_lib.as_ptr()).index },
                 unsafe { (*tree_at.as_ptr()).index },
                 "tree index = {}",
                 i
             );
-            compare(
-                i,
-                "parent",
-                tree_at.parent_array(),
-                tree_at_lib.parent_array(),
-            );
-            compare(
-                i,
-                "parent jk",
-                tree_at_jk.parent_array(),
-                tree_at_lib.parent_array(),
-            );
+            //compare(
+            //    i,
+            //    "parent",
+            //    tree_at.parent_array(),
+            //    tree_at_lib.parent_array(),
+            //);
+            //compare(
+            //    i,
+            //    "parent jk",
+            //    tree_at_jk.parent_array(),
+            //    tree_at_lib.parent_array(),
+            //);
             niterations += 1;
         }
         println!("{}", niterations);

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -124,6 +124,9 @@ fn main() {
             assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
                 (*tree_at.as_ptr()).right_index
             });
+            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).num_edges }, unsafe {
+                (*tree_at_jk.as_ptr()).num_edges
+            });
             assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
                 (*tree_at_jk.as_ptr()).left_index
             });

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -12,6 +12,8 @@ struct Args {
     stepsize: u64,
 }
 
+// NOTE: direct slice comparison (a == b) fails.
+// That may be an issue in tskit-rust?  Need to check that.
 fn compare(tree: u64, name: &str, left: &[NodeId], right: &[NodeId]) {
     for (i, (l, r)) in left.iter().zip(right.iter()).enumerate() {
         if *l != *r {

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -1,0 +1,43 @@
+use std::time::Instant;
+
+use clap::Parser;
+use tskit::prelude::*;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(short, long, value_parser)]
+    treefile: String,
+    #[clap(short, long, value_parser, default_value = "10")]
+    stepsize: u64,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    assert!(args.stepsize > 0);
+
+    let treeseq = tskit::TreeSequence::load(&args.treefile).unwrap();
+    let num_trees: u64 = treeseq.num_trees().into();
+    let flags = tskit::TreeFlags::SAMPLE_LISTS;
+    let indexes = tskit::TreesIndex::new(&treeseq).unwrap();
+
+    for i in (0..num_trees).step_by(args.stepsize as usize) {
+        let now = Instant::now();
+        let tree_at = treeseq
+            .tree_iterator_at_index(i.into(), &indexes, flags)
+            .unwrap();
+        let duration = now.elapsed();
+        let now = Instant::now();
+        let tree_at_lib = treeseq
+            .tree_iterator_at_index_lib(i.into(), &indexes, flags)
+            .unwrap();
+        let duration_lib = now.elapsed();
+        println!(
+            "{} {:?} {:?}",
+            i,
+            duration.as_micros(),
+            duration_lib.as_micros()
+        );
+    }
+}

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -37,7 +37,7 @@ fn main() {
     let indexes = tskit::TreesIndex::new(&treeseq).unwrap();
 
     println!("method index time");
-    for i in (0..num_trees).step_by(args.stepsize as usize) {
+    for i in (0..(num_trees-1)).step_by(args.stepsize as usize) {
         assert!(i < num_trees);
         let now = Instant::now();
         let mut tree_at = treeseq
@@ -48,6 +48,7 @@ fn main() {
         let mut tree_at_lib = treeseq
             .tree_iterator_at_index_lib(i.into(), &indexes, flags)
             .unwrap();
+        // unsafe { (*tree_at_lib.as_mut_ptr()).direction = 1 };
         let duration_lib = now.elapsed();
         let now = Instant::now();
         let mut tree_at_jk = treeseq
@@ -94,12 +95,20 @@ fn main() {
         );
 
         let mut niterations = 0;
-        assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
-            (*tree_at_jk.as_ptr()).left_index
-        });
-        assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
-            (*tree_at_jk.as_ptr()).right_index
-        });
+        //assert_eq!(
+        //    unsafe { (*tree_at_lib.as_ptr()).direction },
+        //    tskit::bindings::TSK_DIR_FORWARD as i32
+        //);
+        assert_eq!(
+            unsafe { (*tree_at_jk.as_ptr()).direction },
+            tskit::bindings::TSK_DIR_FORWARD as i32
+        );
+        //assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
+        //    (*tree_at_jk.as_ptr()).left_index
+        //});
+        //assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
+        //    (*tree_at_jk.as_ptr()).right_index
+        //});
         assert_eq!(unsafe { (*tree_at_lib.as_ptr()).num_edges }, unsafe {
             (*tree_at.as_ptr()).num_edges
         });
@@ -125,6 +134,7 @@ fn main() {
             //    tree_at_lib.parent_array(),
             //);
 
+            //println!("JK");
             let tree_at_jk = tree_at_jk.next().unwrap();
             assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
             assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -148,12 +148,12 @@ fn main() {
             //    ttime_lib,
             //    ttime_jk
             //);
-            //compare(
-            //    i,
-            //    "parent",
-            //    tree_at.parent_array(),
-            //    tree_at_lib.parent_array(),
-            //);
+            compare(
+                i,
+                "parent",
+                tree_at.parent_array(),
+                tree_at_lib.parent_array(),
+            );
             compare(
                 i,
                 "parent jk",

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -13,6 +13,9 @@ struct Args {
 }
 
 fn compare(tree: u64, name: &str, left: &[NodeId], right: &[NodeId]) {
+    let not_null = left.iter().filter(|x| !x.is_null()).count();
+    let not_null_r = right.iter().filter(|x| !x.is_null()).count();
+    assert_eq!(not_null, not_null_r);
     for (i, (l, r)) in left.iter().zip(right.iter()).enumerate() {
         if *l != *r {
             panic!(
@@ -77,12 +80,12 @@ fn main() {
         assert_eq!(tree_at.interval(), tree_at_lib.interval());
         assert_eq!(tree_at_jk.interval(), tree_at_lib.interval());
 
-        compare(
-            i,
-            "parent",
-            tree_at.parent_array(),
-            tree_at_lib.parent_array(),
-        );
+        // compare(
+        //     i,
+        //     "parent",
+        //     tree_at.parent_array(),
+        //     tree_at_lib.parent_array(),
+        // );
         compare(
             i,
             "parent",
@@ -148,12 +151,12 @@ fn main() {
             //    tree_at.parent_array(),
             //    tree_at_lib.parent_array(),
             //);
-            //compare(
-            //    i,
-            //    "parent jk",
-            //    tree_at_jk.parent_array(),
-            //    tree_at_lib.parent_array(),
-            //);
+            compare(
+                i,
+                "parent jk",
+                tree_at_jk.parent_array(),
+                tree_at_lib.parent_array(),
+            );
             niterations += 1;
         }
         println!("{}", niterations);

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -107,26 +107,25 @@ fn main() {
             (*tree_at_jk.as_ptr()).num_edges
         });
         while let Some(tree_at_lib) = tree_at_lib.next() {
-            let tree_at = tree_at.next().unwrap();
-            assert_eq!(tree_at_lib.interval(), tree_at.interval());
-            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {
-                (*tree_at.as_ptr()).index
-            });
-            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
-                (*tree_at.as_ptr()).left_index
-            });
-            assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
-                (*tree_at.as_ptr()).right_index
-            });
-            compare(
-                i,
-                "parent",
-                tree_at.parent_array(),
-                tree_at_lib.parent_array(),
-            );
+            //let tree_at = tree_at.next().unwrap();
+            //assert_eq!(tree_at_lib.interval(), tree_at.interval());
+            //assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {
+            //    (*tree_at.as_ptr()).index
+            //});
+            //assert_eq!(unsafe { (*tree_at_lib.as_ptr()).left_index }, unsafe {
+            //    (*tree_at.as_ptr()).left_index
+            //});
+            //assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
+            //    (*tree_at.as_ptr()).right_index
+            //});
+            //compare(
+            //    i,
+            //    "parent",
+            //    tree_at.parent_array(),
+            //    tree_at_lib.parent_array(),
+            //);
 
             let tree_at_jk = tree_at_jk.next().unwrap();
-
             assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
             assert_eq!(unsafe { (*tree_at_lib.as_ptr()).index }, unsafe {
                 (*tree_at_jk.as_ptr()).index
@@ -140,26 +139,20 @@ fn main() {
             assert_eq!(unsafe { (*tree_at_lib.as_ptr()).right_index }, unsafe {
                 (*tree_at_jk.as_ptr()).right_index
             });
-            assert_eq!(tree_at_lib.interval(), tree_at_jk.interval());
-            assert_eq!(
-                unsafe { (*tree_at_lib.as_ptr()).index },
-                unsafe { (*tree_at_jk.as_ptr()).index },
-                "tree index = {}",
-                i
-            );
-            //let ttime_lib: f64 = tree_at_lib.total_branch_length(false).unwrap().into();
-            //let ttime_jk: f64 = tree_at_jk.total_branch_length(false).unwrap().into();
-            //assert!(
-            //    (ttime_jk - ttime_lib).abs() <= 1e-6,
-            //    "{} {}",
-            //    ttime_lib,
-            //    ttime_jk
-            //);
             compare(
                 i,
                 "parent jk",
                 tree_at_jk.parent_array(),
                 tree_at_lib.parent_array(),
+            );
+
+            let ttime_lib: f64 = tree_at_lib.total_branch_length(false).unwrap().into();
+            let ttime_jk: f64 = tree_at_jk.total_branch_length(false).unwrap().into();
+            assert!(
+                (ttime_jk - ttime_lib).abs() <= 1e-6,
+                "{} {}",
+                ttime_lib,
+                ttime_jk
             );
             niterations += 1;
         }

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -55,6 +55,13 @@ fn main() {
         println!("lib {:?} {:?}", i, duration_lib.as_micros(),);
         println!("jk {:?} {:?}", i, duration_jk.as_micros(),);
 
+        let ttime_at: f64 = tree_at.total_branch_length(false).unwrap().into();
+        let ttime_lib: f64 = tree_at_lib.total_branch_length(false).unwrap().into();
+        let ttime_jk: f64 = tree_at_jk.total_branch_length(false).unwrap().into();
+
+        assert!((ttime_at - ttime_lib).abs() <= 1e-8);
+        assert!((ttime_jk - ttime_lib).abs() <= 1e-8);
+
         compare(
             i,
             "parent",

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -103,6 +103,12 @@ fn main() {
             unsafe { (*tree_at_lib.as_ptr()).right_index },
             unsafe { (*tree_at.as_ptr()).right_index }
         );
+        assert_eq!(unsafe { (*tree_at_lib.as_ptr()).num_edges }, unsafe {
+            (*tree_at.as_ptr()).num_edges
+        });
+        assert_eq!(unsafe { (*tree_at_lib.as_ptr()).num_edges }, unsafe {
+            (*tree_at_jk.as_ptr()).num_edges
+        });
         while let Some(tree_at_lib) = tree_at_lib.next() {
             let tree_at = tree_at.next().unwrap();
             let tree_at_jk = tree_at_jk.next().unwrap();

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -59,8 +59,20 @@ fn main() {
         let ttime_lib: f64 = tree_at_lib.total_branch_length(false).unwrap().into();
         let ttime_jk: f64 = tree_at_jk.total_branch_length(false).unwrap().into();
 
-        assert!((ttime_at - ttime_lib).abs() <= 1e-8);
-        assert!((ttime_jk - ttime_lib).abs() <= 1e-8);
+        // The "liberal" tolerance here is b/c our example
+        // data has large ttl times is abs value.
+        assert!(
+            (ttime_jk - ttime_lib).abs() <= 1e-5,
+            "jk vs lib: {} {}",
+            ttime_jk,
+            ttime_lib
+        );
+        assert!(
+            (ttime_at - ttime_lib).abs() <= 1e-5,
+            "at vs lib: {} {}",
+            ttime_at,
+            ttime_lib
+        );
 
         compare(
             i,

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -12,6 +12,17 @@ struct Args {
     stepsize: u64,
 }
 
+fn compare(tree: u64, name: &str, left: &[NodeId], right: &[NodeId]) {
+    for (i, (l, r)) in left.iter().zip(right.iter()).enumerate() {
+        if *l != *r {
+            panic!(
+                "tree {}, array: {}, index {}, left {}, right {}",
+                tree, name, i, *l, *r
+            );
+        }
+    }
+}
+
 fn main() {
     let args = Args::parse();
 
@@ -23,6 +34,7 @@ fn main() {
     let indexes = tskit::TreesIndex::new(&treeseq).unwrap();
 
     for i in (0..num_trees).step_by(args.stepsize as usize) {
+        assert!(i < num_trees);
         let now = Instant::now();
         let tree_at = treeseq
             .tree_iterator_at_index(i.into(), &indexes, flags)
@@ -38,6 +50,37 @@ fn main() {
             i,
             duration.as_micros(),
             duration_lib.as_micros()
+        );
+
+        compare(
+            i,
+            "parent",
+            tree_at.parent_array(),
+            tree_at_lib.parent_array(),
+        );
+        compare(
+            i,
+            "left_child",
+            tree_at.left_child_array(),
+            tree_at_lib.left_child_array(),
+        );
+        compare(
+            i,
+            "right_child",
+            tree_at.right_child_array(),
+            tree_at_lib.right_child_array(),
+        );
+        compare(
+            i,
+            "left_sib",
+            tree_at.left_sib_array(),
+            tree_at_lib.left_sib_array(),
+        );
+        compare(
+            i,
+            "right_sib",
+            tree_at.right_sib_array(),
+            tree_at_lib.right_sib_array(),
         );
     }
 }

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -46,13 +46,25 @@ fn main() {
             .tree_iterator_at_index_lib(i.into(), &indexes, flags)
             .unwrap();
         let duration_lib = now.elapsed();
+        let now = Instant::now();
+        let tree_at_jk = treeseq
+            .tree_iterator_at_index_jk(i.into(), &indexes, flags)
+            .unwrap();
+        let duration_jk = now.elapsed();
         println!("indexes {:?} {:?}", i, duration.as_micros(),);
         println!("lib {:?} {:?}", i, duration_lib.as_micros(),);
+        println!("jk {:?} {:?}", i, duration_jk.as_micros(),);
 
         compare(
             i,
             "parent",
             tree_at.parent_array(),
+            tree_at_lib.parent_array(),
+        );
+        compare(
+            i,
+            "parent",
+            tree_at_jk.parent_array(),
             tree_at_lib.parent_array(),
         );
 

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -12,8 +12,6 @@ struct Args {
     stepsize: u64,
 }
 
-// NOTE: direct slice comparison (a == b) fails.
-// That may be an issue in tskit-rust?  Need to check that.
 fn compare(tree: u64, name: &str, left: &[NodeId], right: &[NodeId]) {
     for (i, (l, r)) in left.iter().zip(right.iter()).enumerate() {
         if *l != *r {
@@ -57,29 +55,34 @@ fn main() {
             tree_at.parent_array(),
             tree_at_lib.parent_array(),
         );
-        compare(
-            i,
-            "left_child",
-            tree_at.left_child_array(),
-            tree_at_lib.left_child_array(),
-        );
-        compare(
-            i,
-            "right_child",
-            tree_at.right_child_array(),
-            tree_at_lib.right_child_array(),
-        );
-        compare(
-            i,
-            "left_sib",
-            tree_at.left_sib_array(),
-            tree_at_lib.left_sib_array(),
-        );
-        compare(
-            i,
-            "right_sib",
-            tree_at.right_sib_array(),
-            tree_at_lib.right_sib_array(),
-        );
+
+        // The following may not be valid:
+        // the different remove/insert ops
+        // could change orders of stuff in sub-trees?
+
+        //compare(
+        //    i,
+        //    "left_child",
+        //    tree_at.left_child_array(),
+        //    tree_at_lib.left_child_array(),
+        //);
+        //compare(
+        //    i,
+        //    "right_child",
+        //    tree_at.right_child_array(),
+        //    tree_at_lib.right_child_array(),
+        //);
+        //compare(
+        //    i,
+        //    "left_sib",
+        //    tree_at.left_sib_array(),
+        //    tree_at_lib.left_sib_array(),
+        //);
+        //compare(
+        //    i,
+        //    "right_sib",
+        //    tree_at.right_sib_array(),
+        //    tree_at_lib.right_sib_array(),
+        //);
     }
 }

--- a/examples/time_tree_initialization.rs
+++ b/examples/time_tree_initialization.rs
@@ -94,7 +94,6 @@ fn main() {
             tree_at_lib.parent_array(),
         );
 
-        let mut niterations = 0;
         //assert_eq!(
         //    unsafe { (*tree_at_lib.as_ptr()).direction },
         //    tskit::bindings::TSK_DIR_FORWARD as i32
@@ -172,9 +171,7 @@ fn main() {
                 ttime_lib,
                 ttime_jk
             );
-            niterations += 1;
         }
-        println!("{}", niterations);
 
         // The following may not be valid:
         // the different remove/insert ops

--- a/makedata.py
+++ b/makedata.py
@@ -1,0 +1,39 @@
+import msprime
+import argparse
+import sys
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(description="Make some data with msprime")
+
+    parser.add_argument("--nsamples", type=int, help="Number of diploid samples")
+    parser.add_argument("--seqlen", type=float, default=1e8, help="sequence length")
+    parser.add_argument(
+        "--recrate", type=float, default=1e-9, help='Rec rate per "base pair"'
+    )
+    parser.add_argument("--popsize", type=int, default=10000, help="Population size")
+    parser.add_argument(
+        "--treefile", type=str, default="treefile.trees", help="Output file name"
+    )
+
+    return parser
+
+
+def main():
+    parser = make_parser()
+    args = parser.parse_args(sys.argv[1:])
+
+    ts = msprime.sim_ancestry(
+        args.nsamples,
+        sequence_length=args.seqlen,
+        recombination_rate=args.recrate,
+        population_size=args.popsize,
+    )
+
+    print(ts.num_trees)
+
+    ts.dump(args.treefile)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub use table_collection::TableCollection;
 pub use traits::IndividualLocation;
 pub use traits::IndividualParents;
 pub use tree_interface::{NodeTraversalOrder, TreeInterface};
-pub use trees::{Tree, TreeSequence};
+pub use trees::{Tree, TreeSequence, TreesIndex};
 
 // Optional features
 #[cfg(feature = "provenance")]

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -187,10 +187,11 @@ impl Tree {
         let mut j = 0_usize;
         let mut k = 0_usize;
         let mut left = 0.0;
-        let mut right = -1.0;
+        let mut right: f64;
         let seqlen = unsafe { (*ts.as_ref().tables).sequence_length };
 
         while j < num_edges || left <= seqlen {
+            //println!("{} {} {} {} {}", j, k, num_edges, left, seqlen);
             while k < num_edges && edge_right[edge_removal[k] as usize] == left {
                 k += 1;
             }
@@ -213,6 +214,7 @@ impl Tree {
             }
 
             // Boy, lack of total ordering stinks...
+            right = seqlen;
             if j < num_edges {
                 right = if right < edge_left[edge_insertion[j] as usize] {
                     right
@@ -221,10 +223,10 @@ impl Tree {
                 };
             }
             if k < num_edges {
-                right = if right < edge_left[edge_removal[j] as usize] {
+                right = if right < edge_right[edge_removal[j] as usize] {
                     right
                 } else {
-                    edge_left[edge_removal[j] as usize].into()
+                    edge_right[edge_removal[j] as usize].into()
                 };
             }
             if pos >= left && pos < right {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -196,10 +196,10 @@ impl Tree {
     ) -> Result<Self, TskitError> {
         let mut tree = Self::new(ts, flags)?;
 
-        let edge_left = ts.edges().left_slice();
-        let edge_right = ts.edges().right_slice();
-        let edge_parent = ts.edges().parent_slice();
-        let edge_child = ts.edges().child_slice();
+        let edge_left = ts.edges().left_slice_raw();
+        let edge_right = ts.edges().right_slice_raw();
+        let edge_parent = ts.edges().parent_slice_raw();
+        let edge_child = ts.edges().child_slice_raw();
         let num_edges = edge_left.len();
 
         let edge_insertion = unsafe {
@@ -252,14 +252,14 @@ impl Tree {
                 right = if right < edge_left[edge_insertion[j] as usize] {
                     right
                 } else {
-                    edge_left[edge_insertion[j] as usize].into()
+                    edge_left[edge_insertion[j] as usize]
                 };
             }
             if k < num_edges {
                 right = if right < edge_right[edge_removal[k] as usize] {
                     right
                 } else {
-                    edge_right[edge_removal[k] as usize].into()
+                    edge_right[edge_removal[k] as usize]
                 };
             }
             //if pos >= left && pos < right {

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -201,6 +201,7 @@ impl Tree {
         let edge_parent = ts.edges().parent_slice_raw();
         let edge_child = ts.edges().child_slice_raw();
         let num_edges = edge_left.len();
+        assert_eq!(num_edges, ts.edges().num_rows().as_usize());
 
         let edge_insertion = unsafe {
             std::slice::from_raw_parts(
@@ -225,7 +226,7 @@ impl Tree {
         let mut left = 0.0;
 
         //while (j < num_edges || left <= seqlen) && pos >= left {
-        while j < num_edges  && pos >= left {
+        while j < num_edges && pos >= left {
             println!("{} {} {} {} | {}", j, num_edges, left, seqlen, pos);
             while k < num_edges && edge_right[edge_removal[k] as usize] == left {
                 k += 1;

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -457,6 +457,21 @@ impl TreeSequence {
         Ok(tree)
     }
 
+    /// Uses the indexes to cheat to find the right position
+    pub fn tree_iterator_at_index_lib<F: Into<TreeFlags>>(
+        &self,
+        index: SizeType,
+        tree_indexes: &TreesIndex,
+        flags: F,
+    ) -> Result<Tree, TskitError> {
+        let index = index.as_usize();
+        let position = tree_indexes.left[index];
+        let flags = flags.into().bits();
+        let mut tree = Tree::new(self, flags)?;
+        let rv = unsafe { ll_bindings::tsk_tree_seek(tree.as_mut_ptr(), position, flags) };
+        handle_tsk_return_value!(rv, tree)
+    }
+
     /// Get the list of samples as a vector.
     /// # Panics
     ///

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -232,7 +232,6 @@ impl Tree {
 
         //while (j < num_edges || left <= seqlen) && pos >= left {
         while j < num_edges || left <= seqlen {
-            println!("{} {} {} {} | {}", j, num_edges, left, seqlen, pos);
             while k < num_edges && edge_right[edge_removal[k] as usize] == left {
                 k += 1;
             }
@@ -309,16 +308,6 @@ impl Tree {
         unsafe { (*tree.as_mut_ptr()).num_nodes = (*ts.as_ref().tables).nodes.num_rows };
         unsafe { (*tree.as_mut_ptr()).direction = ll_bindings::TSK_DIR_FORWARD as i32 };
         tree.current_tree = tree_index.as_usize() as i32;
-
-        println!(
-            "leaving with {} {}|{}, {} {}|{}",
-            j,
-            tree_indexes.insertion[tree_index.as_usize()],
-            tree_indexes.insertion[tree_index.as_usize() + 1],
-            k,
-            tree_indexes.removal[tree_index.as_usize()],
-            tree_indexes.removal[tree_index.as_usize() + 1],
-        );
 
         assert!(pos >= unsafe { (*tree.as_ptr()).interval.left });
         assert!(pos < unsafe { (*tree.as_ptr()).interval.right });

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -171,6 +171,8 @@ impl Tree {
         } else {
             unsafe { (*ts.as_ref().tables).sequence_length }
         };
+        assert!(unsafe { (*tree.as_mut_ptr()).interval.left } < right);
+
         unsafe { (*tree.as_mut_ptr()).interval.right = right };
 
         // this is the part I am unsure of
@@ -185,6 +187,8 @@ impl Tree {
         unsafe { (*tree.as_mut_ptr()).num_nodes = (*ts.as_ref().tables).nodes.num_rows };
         unsafe { (*tree.as_mut_ptr()).direction = ll_bindings::TSK_DIR_FORWARD as i32 };
         tree.current_tree = tree_index.as_usize() as i32;
+        assert!(pos >= unsafe { (*tree.as_ptr()).interval.left });
+        assert!(pos < unsafe { (*tree.as_ptr()).interval.right });
 
         Ok(tree)
     }
@@ -296,6 +300,7 @@ impl Tree {
         } else {
             unsafe { (*ts.as_ref().tables).sequence_length }
         };
+        assert!(unsafe { (*tree.as_mut_ptr()).interval.left } < right);
         unsafe { (*tree.as_mut_ptr()).interval.right = right };
 
         // this is the part I am unsure of
@@ -314,6 +319,9 @@ impl Tree {
             tree_indexes.removal[tree_index.as_usize()],
             tree_indexes.removal[tree_index.as_usize() + 1],
         );
+
+        assert!(pos >= unsafe { (*tree.as_ptr()).interval.left });
+        assert!(pos < unsafe { (*tree.as_ptr()).interval.right });
 
         Ok(tree)
     }

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -252,6 +252,13 @@ impl Tree {
             }
         }
 
+        // manually determine the tree index
+        let breakpoints = unsafe{std::slice::from_raw_parts(ts.as_ref().breakpoints, ts.num_trees().as_usize())};
+        let i = match breakpoints.iter().position(|b| b > &pos) {
+           Some(value) => value - 1,
+           None => panic!("bad things happened that should be an Err")
+        };
+        assert_eq!(i, tree_index.as_usize());
         // clunky -- seems we should be working with i32 and not a size type.
         unsafe { (*tree.as_mut_ptr()).index = tree_index.as_usize() as i32 };
         unsafe { (*tree.as_mut_ptr()).interval.left = pos };

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -183,6 +183,7 @@ impl Tree {
                 tree_indexes.removal[tree_index.as_usize() + 1] as i32
         };
         unsafe { (*tree.as_mut_ptr()).num_nodes = (*ts.as_ref().tables).nodes.num_rows };
+        unsafe { (*tree.as_mut_ptr()).direction = ll_bindings::TSK_DIR_FORWARD as i32 };
         tree.current_tree = tree_index.as_usize() as i32;
 
         Ok(tree)
@@ -301,6 +302,7 @@ impl Tree {
         unsafe { (*tree.as_mut_ptr()).left_index = j as i32 };
         unsafe { (*tree.as_mut_ptr()).right_index = k as i32 };
         unsafe { (*tree.as_mut_ptr()).num_nodes = (*ts.as_ref().tables).nodes.num_rows };
+        unsafe { (*tree.as_mut_ptr()).direction = ll_bindings::TSK_DIR_FORWARD as i32 };
         tree.current_tree = tree_index.as_usize() as i32;
 
         println!(

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -231,7 +231,7 @@ impl Tree {
         let mut left = 0.0;
 
         //while (j < num_edges || left <= seqlen) && pos >= left {
-        while j < num_edges && pos >= left {
+        while j < num_edges || left <= seqlen {
             println!("{} {} {} {} | {}", j, num_edges, left, seqlen, pos);
             while k < num_edges && edge_right[edge_removal[k] as usize] == left {
                 k += 1;
@@ -240,8 +240,8 @@ impl Tree {
                 if pos >= edge_left[edge_insertion[j] as usize]
                     && pos < edge_right[edge_insertion[j] as usize]
                 {
-                    let p: i32 = edge_parent[edge_insertion[j] as usize].into();
-                    let c: i32 = edge_child[edge_insertion[j] as usize].into();
+                    let p: i32 = edge_parent[edge_insertion[j] as usize];
+                    let c: i32 = edge_child[edge_insertion[j] as usize];
                     unsafe {
                         ll_bindings::tsk_tree_insert_edge(
                             tree.as_mut_ptr(),
@@ -268,9 +268,9 @@ impl Tree {
                     edge_right[edge_removal[k] as usize]
                 };
             }
-            //if pos >= left && pos < right {
-            //    break;
-            //}
+            if pos >= left && pos < right {
+                break;
+            }
             left = right;
         }
         // HACK: why is this needed?

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -274,10 +274,10 @@ impl Tree {
             left = right;
         }
         // HACK: why is this needed?
-        if pos > seqlen / 2. {
-            j -= 1;
-            k -= 1;
-        }
+        //if pos > seqlen / 2. {
+        //    j -= 1;
+        //    k -= 1;
+        //}
         // manually determine the tree index
         let breakpoints = unsafe {
             std::slice::from_raw_parts(ts.as_ref().breakpoints, ts.num_trees().as_usize())

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -229,34 +229,38 @@ impl Tree {
         //let pos = tree_indexes.left[tree_index.as_usize()];
 
         let seqlen = unsafe { (*ts.as_ref().tables).sequence_length };
-        let mut j: usize = 0;
+        let mut j: i32 = -1;
 
         if pos <= seqlen / 2. {
-            while j < num_edges {
-                if edge_left[edge_insertion[j] as usize] > pos {
+            let mut edge = 0_usize;
+            while edge < num_edges {
+                let e = edge_insertion[edge];
+                if edge_left[e as usize] > pos {
+                    j = edge as i32;
                     break;
                 }
-                if pos >= edge_left[edge_insertion[j] as usize]
-                    && pos < edge_right[edge_insertion[j] as usize]
-                {
+                if pos >= edge_left[e as usize] && pos < edge_right[e as usize] {
                     unsafe {
                         ll_bindings::tsk_tree_insert_edge(
                             tree.as_mut_ptr(),
-                            edge_parent[edge_insertion[j] as usize],
-                            edge_child[edge_insertion[j] as usize],
-                            edge_insertion[j],
+                            edge_parent[e as usize],
+                            edge_child[e as usize],
+                            e,
                         )
                     };
                 }
-                j += 1;
+                edge += 1;
             }
         } else {
-            while j < num_edges {
-                let e = num_edges - j - 1;
+            let mut edge = 0_usize;
+            while edge < num_edges {
+                let e = num_edges - edge - 1;
                 if edge_right[edge_removal[e] as usize] < pos {
                     // TODO: is this general?
-                    j = e;
-                    while j < num_edges && edge_left[edge_insertion[j] as usize] <= pos {
+                    j = e as i32;
+                    while j < num_edges as i32
+                        && edge_left[edge_insertion[j as usize] as usize] <= pos
+                    {
                         j += 1;
                     }
                     break;
@@ -273,6 +277,13 @@ impl Tree {
                         )
                     };
                 }
+                edge += 1;
+            }
+        }
+
+        if j == -1 {
+            j = 0;
+            while j < num_edges as i32 && edge_left[edge_insertion[j as usize] as usize] <= pos {
                 j += 1;
             }
         }

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -134,6 +134,23 @@ impl Tree {
             }
         }
 
+        // clunky -- seems we should be working with i32 and not a size type.
+        unsafe { *tree.as_mut_ptr() }.index = tree_index.as_usize() as i32;
+        unsafe { *tree.as_mut_ptr() }.interval.left = pos;
+
+        let num_trees: u64 = ts.num_trees().into();
+        unsafe { *tree.as_mut_ptr() }.interval.right = if tree_index < num_trees - 1 {
+            tree_indexes.left[tree_index.as_usize() + 1]
+        } else {
+            unsafe { (*ts.as_ref().tables).sequence_length }
+        };
+
+        // this is the part I am unsure of
+        unsafe { *tree.as_mut_ptr() }.left_index =
+            tree_indexes.insertion[tree_index.as_usize()] as i32;
+        unsafe { *tree.as_mut_ptr() }.right_index =
+            tree_indexes.removal[tree_index.as_usize()] as i32;
+
         Ok(tree)
     }
 }
@@ -425,6 +442,17 @@ impl TreeSequence {
     /// ```
     pub fn tree_iterator<F: Into<TreeFlags>>(&self, flags: F) -> Result<Tree, TskitError> {
         let tree = Tree::new(self, flags)?;
+
+        Ok(tree)
+    }
+
+    pub fn tree_iterator_at_index<F: Into<TreeFlags>>(
+        &self,
+        index: SizeType,
+        tree_indexes: &TreesIndex,
+        flags: F,
+    ) -> Result<Tree, TskitError> {
+        let tree = Tree::new_at_index(self, index, tree_indexes, flags)?;
 
         Ok(tree)
     }

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -175,14 +175,14 @@ impl Tree {
 
         // this is the part I am unsure of
         unsafe {
-            (*tree.as_mut_ptr()).left_index = tree_indexes.insertion[tree_index.as_usize()] as i32
+            (*tree.as_mut_ptr()).left_index =
+                tree_indexes.insertion[tree_index.as_usize() + 1] as i32
         };
         unsafe {
-            (*tree.as_mut_ptr()).right_index = tree_indexes.removal[tree_index.as_usize()] as i32
+            (*tree.as_mut_ptr()).right_index =
+                tree_indexes.removal[tree_index.as_usize() + 1] as i32
         };
-        unsafe {
-            (*tree.as_mut_ptr()).num_nodes = (*ts.as_ref().tables).nodes.num_rows
-        };
+        unsafe { (*tree.as_mut_ptr()).num_nodes = (*ts.as_ref().tables).nodes.num_rows };
         tree.current_tree = tree_index.as_usize() as i32;
 
         Ok(tree)
@@ -282,14 +282,14 @@ impl Tree {
 
         // this is the part I am unsure of
         unsafe {
-            (*tree.as_mut_ptr()).left_index = tree_indexes.insertion[tree_index.as_usize()] as i32
+            (*tree.as_mut_ptr()).left_index =
+                tree_indexes.insertion[tree_index.as_usize() + 1] as i32
         };
         unsafe {
-            (*tree.as_mut_ptr()).right_index = tree_indexes.removal[tree_index.as_usize()] as i32
+            (*tree.as_mut_ptr()).right_index =
+                tree_indexes.removal[tree_index.as_usize() + 1] as i32
         };
-        unsafe {
-            (*tree.as_mut_ptr()).num_nodes = (*ts.as_ref().tables).nodes.num_rows
-        };
+        unsafe { (*tree.as_mut_ptr()).num_nodes = (*ts.as_ref().tables).nodes.num_rows };
         tree.current_tree = tree_index.as_usize() as i32;
 
         Ok(tree)

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -161,21 +161,25 @@ impl Tree {
         }
 
         // clunky -- seems we should be working with i32 and not a size type.
-        unsafe { *tree.as_mut_ptr() }.index = tree_index.as_usize() as i32;
-        unsafe { *tree.as_mut_ptr() }.interval.left = pos;
+        unsafe { (*tree.as_mut_ptr()).index = tree_index.as_usize() as i32 };
+        unsafe { (*tree.as_mut_ptr()).interval.left = pos };
 
         let num_trees: u64 = ts.num_trees().into();
-        unsafe { *tree.as_mut_ptr() }.interval.right = if tree_index < num_trees - 1 {
+
+        let right = if tree_index < num_trees - 1 {
             tree_indexes.left[tree_index.as_usize() + 1]
         } else {
             unsafe { (*ts.as_ref().tables).sequence_length }
         };
+        unsafe { (*tree.as_mut_ptr()).interval.right = right };
 
         // this is the part I am unsure of
-        unsafe { *tree.as_mut_ptr() }.left_index =
-            tree_indexes.insertion[tree_index.as_usize()] as i32;
-        unsafe { *tree.as_mut_ptr() }.right_index =
-            tree_indexes.removal[tree_index.as_usize()] as i32;
+        unsafe {
+            (*tree.as_mut_ptr()).left_index = tree_indexes.insertion[tree_index.as_usize()] as i32
+        };
+        unsafe {
+            (*tree.as_mut_ptr()).right_index = tree_indexes.removal[tree_index.as_usize()] as i32
+        };
 
         Ok(tree)
     }
@@ -263,21 +267,25 @@ impl Tree {
         }
 
         // clunky -- seems we should be working with i32 and not a size type.
-        unsafe { *tree.as_mut_ptr() }.index = tree_index.as_usize() as i32;
-        unsafe { *tree.as_mut_ptr() }.interval.left = pos;
+        unsafe { (*tree.as_mut_ptr()).index = tree_index.as_usize() as i32 };
+        unsafe { (*tree.as_mut_ptr()).interval.left = pos };
 
         let num_trees: u64 = ts.num_trees().into();
-        unsafe { *tree.as_mut_ptr() }.interval.right = if tree_index < num_trees - 1 {
+
+        let right = if tree_index < num_trees - 1 {
             tree_indexes.left[tree_index.as_usize() + 1]
         } else {
-            seqlen
+            unsafe { (*ts.as_ref().tables).sequence_length }
         };
+        unsafe { (*tree.as_mut_ptr()).interval.right = right };
 
         // this is the part I am unsure of
-        unsafe { *tree.as_mut_ptr() }.left_index =
-            tree_indexes.insertion[tree_index.as_usize()] as i32;
-        unsafe { *tree.as_mut_ptr() }.right_index =
-            tree_indexes.removal[tree_index.as_usize()] as i32;
+        unsafe {
+            (*tree.as_mut_ptr()).left_index = tree_indexes.insertion[tree_index.as_usize()] as i32
+        };
+        unsafe {
+            (*tree.as_mut_ptr()).right_index = tree_indexes.removal[tree_index.as_usize()] as i32
+        };
 
         Ok(tree)
     }

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -261,10 +261,9 @@ impl Tree {
                     edge_right[edge_removal[k] as usize].into()
                 };
             }
-            if edge_left[edge_insertion[j] as usize] > pos { break; }
-            //if pos >= left && pos < right {
-            //    break;
-            //}
+            if pos >= left && pos < right {
+                break;
+            }
             left = right;
         }
         // HACK: why is this needed?

--- a/src/trees.rs
+++ b/src/trees.rs
@@ -224,7 +224,8 @@ impl Tree {
         let mut right: f64;
         let mut left = 0.0;
 
-        while j < num_edges || left <= seqlen {
+        //while (j < num_edges || left <= seqlen) && pos >= left {
+        while j < num_edges  && pos >= left {
             println!("{} {} {} {} | {}", j, num_edges, left, seqlen, pos);
             while k < num_edges && edge_right[edge_removal[k] as usize] == left {
                 k += 1;
@@ -261,9 +262,9 @@ impl Tree {
                     edge_right[edge_removal[k] as usize].into()
                 };
             }
-            if pos >= left && pos < right {
-                break;
-            }
+            //if pos >= left && pos < right {
+            //    break;
+            //}
             left = right;
         }
         // HACK: why is this needed?
@@ -300,6 +301,16 @@ impl Tree {
         unsafe { (*tree.as_mut_ptr()).right_index = k as i32 };
         unsafe { (*tree.as_mut_ptr()).num_nodes = (*ts.as_ref().tables).nodes.num_rows };
         tree.current_tree = tree_index.as_usize() as i32;
+
+        println!(
+            "leaving with {} {}|{}, {} {}|{}",
+            j,
+            tree_indexes.insertion[tree_index.as_usize()],
+            tree_indexes.insertion[tree_index.as_usize() + 1],
+            k,
+            tree_indexes.removal[tree_index.as_usize()],
+            tree_indexes.removal[tree_index.as_usize() + 1],
+        );
 
         Ok(tree)
     }

--- a/subprojects/tskit/tskit/trees.c
+++ b/subprojects/tskit/tskit/trees.c
@@ -4294,7 +4294,7 @@ tsk_tree_remove_edge(tsk_tree_t *self, tsk_id_t p, tsk_id_t c)
     }
 }
 
-static void
+void
 tsk_tree_insert_edge(tsk_tree_t *self, tsk_id_t p, tsk_id_t c, tsk_id_t edge_id)
 {
     tsk_id_t *restrict parent = self->parent;

--- a/subprojects/tskit/tskit/trees.h
+++ b/subprojects/tskit/tskit/trees.h
@@ -1039,6 +1039,9 @@ work as expected and for compatibility with future versions of tskit.
 int tsk_tree_init(
     tsk_tree_t *self, const tsk_treeseq_t *tree_sequence, tsk_flags_t options);
 
+void
+tsk_tree_insert_edge(tsk_tree_t *self, tsk_id_t p, tsk_id_t c, tsk_id_t edge_id);
+
 /**
 @brief Free the internal memory for the specified tree.
 


### PR DESCRIPTION
Implement efficient tree indexing in rust.

The problem is that we need to expose some private C API to the public, which is
not going to fly.
Hence, this is just a proof of concept.
