### PR TITLE
Add type for managing pointers to tskit-c types.

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -380,56 +380,6 @@ macro_rules! handle_metadata_return {
     };
 }
 
-macro_rules! build_owned_tables {
-    ($name: ty, $deref: ident, $lltype: ty, $tsktable: ty) => {
-        impl $name {
-            fn new() -> Self {
-                let table = <$lltype>::new();
-                Self { table }
-            }
-
-            /// Clear the table.
-            pub fn clear(&mut self) -> $crate::TskReturnValue {
-                self.table.clear().map_err(|e| e.into())
-            }
-        }
-
-        impl Default for $name {
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-
-        impl std::ops::Deref for $name {
-            type Target = $deref;
-
-            fn deref(&self) -> &Self::Target {
-                // SAFETY: that T* and &T have same layout,
-                // and Target is repr(transparent).
-                unsafe { std::mem::transmute(&self.table) }
-            }
-        }
-
-        impl std::ops::DerefMut for $name {
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                // SAFETY: that T* and &T have same layout,
-                // and Target is repr(transparent).
-                unsafe { std::mem::transmute(&mut self.table) }
-            }
-        }
-
-        impl $name {
-            pub fn as_ptr(&self) -> *const $tsktable {
-                self.table.as_ptr()
-            }
-
-            pub fn as_mut_ptr(&mut self) -> *mut $tsktable {
-                self.table.as_mut_ptr()
-            }
-        }
-    };
-}
-
 macro_rules! node_table_add_row_details {
     ($flags: ident,
      $time: ident,
@@ -926,25 +876,6 @@ macro_rules! provenance_table_add_row {
             };
             handle_tsk_return_value!(rv, rv.into())
         }
-    };
-}
-
-macro_rules! build_owned_table_type {
-    ($(#[$attr:meta])* => $name: ident,
-    $deref_type: ident,
-    $lltype: ty,
-    $tsktable: ty) => {
-        $(#[$attr])*
-        pub struct $name {
-            table: $lltype
-        }
-
-        build_owned_tables!(
-            $name,
-            $deref_type,
-            $lltype,
-            $tsktable
-        );
     };
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,8 +40,11 @@ pub enum TskitError {
 impl From<crate::sys::Error> for TskitError {
     fn from(error: sys::Error) -> Self {
         match error {
-            sys::Error::Message(msg) => TskitError::LibraryError(msg),
             sys::Error::Code(code) => TskitError::ErrorCode { code },
+            sys::Error::Message(msg) => TskitError::LibraryError(msg),
+            sys::Error::NullPointer => {
+                TskitError::LibraryError("null pointer encountered".to_owned())
+            }
         }
     }
 }

--- a/src/individual_table.rs
+++ b/src/individual_table.rs
@@ -95,15 +95,58 @@ impl<'a> streaming_iterator::StreamingIterator for IndividualTableRowView<'a> {
     }
 }
 
-/// An immutable view of a individual table.
+/// An individual table.
 ///
-/// These are not created directly but are accessed
-/// by types implementing [`std::ops::Deref`] to
-/// [`crate::table_views::TableViews`]
+/// # Examples
+///
+/// ## Standalone tables
+///
+/// ```
+/// use tskit::IndividualTable;
+///
+/// let mut individuals = IndividualTable::default();
+/// let rowid = individuals.add_row(0, None, None).unwrap();
+/// assert_eq!(rowid, 0);
+/// assert_eq!(individuals.num_rows(), 1);
+/// ```
+///
+/// An example with metadata.
+/// This requires the cargo feature `"derive"` for `tskit`.
+///
+///
+/// ```
+/// # #[cfg(any(feature="doc", feature="derive"))] {
+/// use tskit::IndividualTable;
+///
+/// #[derive(serde::Serialize,
+///          serde::Deserialize,
+///          tskit::metadata::IndividualMetadata)]
+/// #[serializer("serde_json")]
+/// struct IndividualMetadata {
+///     value: i32,
+/// }
+///
+/// let metadata = IndividualMetadata{value: 42};
+///
+/// let mut individuals = IndividualTable::default();
+///
+/// let rowid = individuals.add_row_with_metadata(0, None, None, &metadata).unwrap();
+/// assert_eq!(rowid, 0);
+///
+/// match individuals.metadata::<IndividualMetadata>(rowid) {
+///     // rowid is in range, decoding succeeded
+///     Some(Ok(decoded)) => assert_eq!(decoded.value, 42),
+///     // rowid is in range, decoding failed
+///     Some(Err(e)) => panic!("error decoding metadata: {:?}", e),
+///     None => panic!("row id out of range")
+/// }
+///
+/// # }
+/// ```
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct IndividualTable {
-    table_: sys::LLIndividualTableRef,
+    table_: sys::LLIndividualTable,
 }
 
 fn make_individual_table_row(table: &IndividualTable, pos: tsk_id_t) -> Option<IndividualTableRow> {
@@ -141,10 +184,23 @@ impl Iterator for IndividualTableIterator {
 }
 
 impl IndividualTable {
+    pub fn new() -> Result<Self, TskitError> {
+        let table_ = sys::LLIndividualTable::new_owning(0)?;
+        Ok(Self { table_ })
+    }
+
+    pub(crate) fn as_ptr(&self) -> *const ll_bindings::tsk_individual_table_t {
+        self.table_.as_ptr()
+    }
+
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut ll_bindings::tsk_individual_table_t {
+        self.table_.as_mut_ptr()
+    }
+
     pub(crate) fn new_from_table(
         individuals: *mut ll_bindings::tsk_individual_table_t,
     ) -> Result<Self, TskitError> {
-        let table_ = sys::LLIndividualTableRef::new_from_table(individuals)?;
+        let table_ = sys::LLIndividualTable::new_non_owning(individuals)?;
         Ok(IndividualTable { table_ })
     }
 
@@ -431,6 +487,13 @@ match tables.individuals().metadata::<MutationMetadata>(0.into())
         Some(view)
     }
 
+    pub fn clear(&mut self) -> Result<(), TskitError> {
+        self.table_.clear().map_err(|e| e.into())
+    }
+
+    individual_table_add_row!(=> add_row, self, self.as_mut_ptr());
+    individual_table_add_row_with_metadata!(=> add_row_with_metadata, self, self.as_mut_ptr());
+
     build_table_column_slice_getter!(
         /// Get the flags column as a slice
         => flags, flags_slice, IndividualFlags);
@@ -439,60 +502,10 @@ match tables.individuals().metadata::<MutationMetadata>(0.into())
         => flags, flags_slice_raw, ll_bindings::tsk_flags_t);
 }
 
-build_owned_table_type!(
-    /// A standalone individual table that owns its data.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tskit::OwningIndividualTable;
-    ///
-    /// let mut individuals = OwningIndividualTable::default();
-    /// let rowid = individuals.add_row(0, None, None).unwrap();
-    /// assert_eq!(rowid, 0);
-    /// assert_eq!(individuals.num_rows(), 1);
-    /// ```
-    ///
-    /// An example with metadata.
-    /// This requires the cargo feature `"derive"` for `tskit`.
-    ///
-    ///
-    /// ```
-    /// # #[cfg(any(feature="doc", feature="derive"))] {
-    /// use tskit::OwningIndividualTable;
-    ///
-    /// #[derive(serde::Serialize,
-    ///          serde::Deserialize,
-    ///          tskit::metadata::IndividualMetadata)]
-    /// #[serializer("serde_json")]
-    /// struct IndividualMetadata {
-    ///     value: i32,
-    /// }
-    ///
-    /// let metadata = IndividualMetadata{value: 42};
-    ///
-    /// let mut individuals = OwningIndividualTable::default();
-    ///
-    /// let rowid = individuals.add_row_with_metadata(0, None, None, &metadata).unwrap();
-    /// assert_eq!(rowid, 0);
-    ///
-    /// match individuals.metadata::<IndividualMetadata>(rowid) {
-    ///     // rowid is in range, decoding succeeded
-    ///     Some(Ok(decoded)) => assert_eq!(decoded.value, 42),
-    ///     // rowid is in range, decoding failed
-    ///     Some(Err(e)) => panic!("error decoding metadata: {:?}", e),
-    ///     None => panic!("row id out of range")
-    /// }
-    ///
-    /// # }
-    /// ```
-    => OwningIndividualTable,
-    IndividualTable,
-    crate::sys::LLOwningIndividualTable,
-    crate::bindings::tsk_individual_table_t
-);
-
-impl OwningIndividualTable {
-    individual_table_add_row!(=> add_row, self, self.as_mut_ptr());
-    individual_table_add_row_with_metadata!(=> add_row_with_metadata, self, self.as_mut_ptr());
+impl Default for IndividualTable {
+    fn default() -> Self {
+        Self::new().unwrap()
+    }
 }
+
+pub type OwningIndividualTable = IndividualTable;

--- a/src/mutation_table.rs
+++ b/src/mutation_table.rs
@@ -154,27 +154,80 @@ impl<'a> streaming_iterator::StreamingIterator for MutationTableRowView<'a> {
     }
 }
 
-/// An immutable view of site table.
+/// A mutation table
 ///
-/// These are not created directly but are accessed
-/// by types implementing [`std::ops::Deref`] to
-/// [`crate::table_views::TableViews`]
+/// # Examples
+///
+/// # Standalone tables
+///
+/// ```
+/// use tskit::MutationTable;
+///
+/// let mut mutations = MutationTable::default();
+/// let rowid = mutations.add_row(1, 2, 0, 1.0, None).unwrap();
+/// assert_eq!(rowid, 0);
+/// assert_eq!(mutations.num_rows(), 1);
+/// ```
+///
+/// An example with metadata.
+/// This requires the cargo feature `"derive"` for `tskit`.
+///
+/// ```
+/// # #[cfg(any(feature="doc", feature="derive"))] {
+/// use tskit::MutationTable;
+///
+/// #[derive(serde::Serialize,
+///          serde::Deserialize,
+///          tskit::metadata::MutationMetadata)]
+/// #[serializer("serde_json")]
+/// struct MutationMetadata {
+///     value: i32,
+/// }
+///
+/// let metadata = MutationMetadata{value: 42};
+///
+/// let mut mutations = MutationTable::default();
+///
+/// let rowid = mutations.add_row_with_metadata(0, 1, 5, 10.0, None, &metadata).unwrap();
+/// assert_eq!(rowid, 0);
+///
+/// match mutations.metadata::<MutationMetadata>(rowid) {
+///     // rowid is in range, decoding succeeded
+///     Some(Ok(decoded)) => assert_eq!(decoded.value, 42),
+///     // rowid is in range, decoding failed
+///     Some(Err(e)) => panic!("error decoding metadata: {:?}", e),
+///     None => panic!("row id out of range")
+/// }
+/// # }
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct MutationTable {
-    table_: sys::LLMutationTableRef,
+    table_: sys::LLMutationTable,
 }
 
 impl MutationTable {
+    pub(crate) fn as_ptr(&self) -> *const ll_bindings::tsk_mutation_table_t {
+        self.table_.as_ptr()
+    }
+
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut ll_bindings::tsk_mutation_table_t {
+        self.table_.as_mut_ptr()
+    }
+
     pub(crate) fn new_from_table(
         mutations: *mut ll_bindings::tsk_mutation_table_t,
     ) -> Result<Self, TskitError> {
-        let table_ = sys::LLMutationTableRef::new_from_table(mutations)?;
+        let table_ = sys::LLMutationTable::new_non_owning(mutations)?;
         Ok(MutationTable { table_ })
     }
 
     pub(crate) fn as_ref(&self) -> &ll_bindings::tsk_mutation_table_t {
         self.table_.as_ref()
+    }
+
+    pub fn new() -> Result<Self, TskitError> {
+        let table_ = sys::LLMutationTable::new_owning(0)?;
+        Ok(Self { table_ })
     }
 
     /// Return the number of rows.
@@ -321,6 +374,13 @@ impl MutationTable {
         Some(view)
     }
 
+    pub fn clear(&mut self) -> Result<(), TskitError> {
+        self.table_.clear().map_err(|e| e.into())
+    }
+
+    mutation_table_add_row!(=> add_row, self, self.as_mut_ptr());
+    mutation_table_add_row_with_metadata!(=> add_row_with_metadata, self, self.as_mut_ptr());
+
     build_table_column_slice_getter!(
         /// Get the node column as a slice
         => node, node_slice, NodeId);
@@ -347,58 +407,10 @@ impl MutationTable {
         => parent, parent_slice_raw, crate::tsk_id_t);
 }
 
-build_owned_table_type!(
-/// A standalone mutation table that owns its data.
-///
-/// # Examples
-///
-/// ```
-/// use tskit::OwningMutationTable;
-///
-/// let mut mutations = OwningMutationTable::default();
-/// let rowid = mutations.add_row(1, 2, 0, 1.0, None).unwrap();
-/// assert_eq!(rowid, 0);
-/// assert_eq!(mutations.num_rows(), 1);
-/// ```
-///
-/// An example with metadata.
-/// This requires the cargo feature `"derive"` for `tskit`.
-///
-/// ```
-/// # #[cfg(any(feature="doc", feature="derive"))] {
-/// use tskit::OwningMutationTable;
-///
-/// #[derive(serde::Serialize,
-///          serde::Deserialize,
-///          tskit::metadata::MutationMetadata)]
-/// #[serializer("serde_json")]
-/// struct MutationMetadata {
-///     value: i32,
-/// }
-///
-/// let metadata = MutationMetadata{value: 42};
-///
-/// let mut mutations = OwningMutationTable::default();
-///
-/// let rowid = mutations.add_row_with_metadata(0, 1, 5, 10.0, None, &metadata).unwrap();
-/// assert_eq!(rowid, 0);
-///
-/// match mutations.metadata::<MutationMetadata>(rowid) {
-///     // rowid is in range, decoding succeeded
-///     Some(Ok(decoded)) => assert_eq!(decoded.value, 42),
-///     // rowid is in range, decoding failed
-///     Some(Err(e)) => panic!("error decoding metadata: {:?}", e),
-///     None => panic!("row id out of range")
-/// }
-/// # }
-/// ```
-    => OwningMutationTable,
-    MutationTable,
-    crate::sys::LLOwningMutationTable,
-    crate::bindings::tsk_mutation_table_t
-);
-
-impl OwningMutationTable {
-    mutation_table_add_row!(=> add_row, self, self.as_mut_ptr());
-    mutation_table_add_row_with_metadata!(=> add_row_with_metadata, self, self.as_mut_ptr());
+impl Default for MutationTable {
+    fn default() -> Self {
+        Self::new().unwrap()
+    }
 }
+
+pub type OwningMutationTable = MutationTable;


### PR DESCRIPTION
This PR is a WIP to:

1. Work out a new type in sys.rs to manage pointers to tskit-c types.
2. Support types that do and do not own the pointed-to data.
   a. The first case means a malloc'd pointer.
   b. The second case means a reference to a pointer owned by
      another object. For example, and edge table owned by a table
      collection.

Related issues:

1. #439
2. #449

Closes #439
