### PR TITLE
refactor: remove generic from TableCollection::simplify

### DIFF
--- a/src/table_collection.rs
+++ b/src/table_collection.rs
@@ -947,9 +947,9 @@ impl TableCollection {
     ///   in length to the input node table.  For each input node,
     ///   this vector either contains the node's new index or [`NodeId::NULL`]
     ///   if the input node is not part of the simplified history.
-    pub fn simplify<N: Into<NodeId>, O: Into<SimplificationOptions>>(
+    pub fn simplify<O: Into<SimplificationOptions>>(
         &mut self,
-        samples: &[N],
+        samples: &[NodeId],
         options: O,
         idmap: bool,
     ) -> Result<Option<&[NodeId]>, TskitError> {


### PR DESCRIPTION
* The generic was unsound and could lead to UB if
  sizeof(type) and ABI of type were not identical
  to NodeId

BREAKING CHANGE: removing the generic changes fn signature
