### PR TITLE
chore: bump MSRV to 1.60.0

### DIFF
--- a/.github/workflows/test32bit.yml
+++ b/.github/workflows/test32bit.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest]
         rust:
           - stable
-          - 1.57.0
+          - 1.60.0
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         rust:
           - stable
-          - 1.57.0
+          - 1.60.0
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -66,7 +66,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.57.0
+          - 1.60.0
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "rust interface to tskit"
 license = "MIT"
 homepage = "https://github.com/tskit-dev/tskit-rust"
 repository = "https://github.com/tskit-dev/tskit-rust"
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
A dependency (humantime) forces the change.

BREAKING CHANGE: older rustc (Before April 2022) no longer
supported
