### PR TITLE
add treeseq liftime to Tree

### DIFF
--- a/examples/haploid_wright_fisher.rs
+++ b/examples/haploid_wright_fisher.rs
@@ -161,7 +161,7 @@ proptest! {
                     assert!(b2 >= 0, "{}", b2);
                     assert!(f64::from(b) - x <= 1e-8);
                 }
-            }
+            };
         }
     }
 }


### PR DESCRIPTION
* C tree contains ptr to treeseq
* No easy way to express this in rust
* So, we add a lifetime and a reference.
