### PR TITLE
refactor: remove TSK_NODE_IS_SAMPLE

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -979,7 +979,7 @@ macro_rules! delegate_table_view_api {
                 pub fn provenances_iter(&self,) -> impl Iterator<Item = crate::provenance::ProvenanceTableRow> + '_;
 
                 /// Obtain a vector containing the indexes ("ids")
-                /// of all nodes for which [`crate::TSK_NODE_IS_SAMPLE`]
+                /// of all nodes for which [`crate::NodeFlags::is_sample`]
                 /// is `true`.
                 ///
                 /// The provided implementation dispatches to
@@ -1006,11 +1006,11 @@ macro_rules! delegate_table_view_api {
                 /// ```
                 /// let mut tables = tskit::TableCollection::new(100.).unwrap();
                 /// tables
-                ///     .add_node(tskit::TSK_NODE_IS_SAMPLE, 0.0, tskit::PopulationId::NULL,
+                ///     .add_node(tskit::NodeFlags::new_sample(), 0.0, tskit::PopulationId::NULL,
                 ///     tskit::IndividualId::NULL)
                 ///     .unwrap();
                 /// tables
-                ///     .add_node(tskit::TSK_NODE_IS_SAMPLE, 1.0, tskit::PopulationId::NULL,
+                ///     .add_node(tskit::NodeFlags::new_sample(), 1.0, tskit::PopulationId::NULL,
                 ///     tskit::IndividualId::NULL)
                 ///     .unwrap();
                 /// let samples = tables.create_node_id_vector(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,10 +100,6 @@ mod trees;
 pub mod types;
 mod util;
 
-// re-export fundamental constants that
-// we can't live without
-pub use bindings::TSK_NODE_IS_SAMPLE;
-
 // re-export types, too
 pub use bindings::tsk_flags_t;
 

--- a/src/node_table.rs
+++ b/src/node_table.rs
@@ -543,7 +543,7 @@ impl NodeTable {
     /// ```
     /// # use tskit::prelude::*;
     /// # let mut tables = tskit::TableCollection::new(10.).unwrap();
-    /// # tables.add_node(tskit::NodeFlags::IS_SAMPLE, 10.0, -1, -1).unwrap();
+    /// # tables.add_node(tskit::NodeFlags::new_sample(), 10.0, -1, -1).unwrap();
     /// if let Some(flags) = tables.nodes().flags(0) {
     /// // then node id 0 is a valid row id
     /// # assert!(flags.is_sample());
@@ -714,10 +714,10 @@ impl NodeTable {
         Some(view)
     }
     /// Obtain a vector containing the indexes ("ids")
-    /// of all nodes for which [`crate::TSK_NODE_IS_SAMPLE`]
+    /// of all nodes for which [`crate::NodeFlags::is_sample`]
     /// is `true`.
     pub fn samples_as_vector(&self) -> Vec<NodeId> {
-        self.create_node_id_vector(|row| row.flags.contains(NodeFlags::IS_SAMPLE))
+        self.create_node_id_vector(|row| row.flags.contains(NodeFlags::new_sample()))
     }
 
     /// Obtain a vector containing the indexes ("ids") of all nodes
@@ -746,7 +746,7 @@ impl NodeTable {
     /// ```compile_fail
     /// # use tskit::prelude::*;
     /// # let mut tables = tskit::TableCollection::new(10.).unwrap();
-    /// # tables.add_node(tskit::NodeFlags::IS_SAMPLE, 10.0, -1, -1).unwrap();
+    /// # tables.add_node(tskit::NodeFlags::new_sample(), 10.0, -1, -1).unwrap();
     /// let time = tables.nodes().time_slice_mut();
     /// println!("{}", time.len()); // ERROR: the temporary node table is dropped by now
     /// ```
@@ -756,7 +756,7 @@ impl NodeTable {
     /// ```
     /// # use tskit::prelude::*;
     /// # let mut tables = tskit::TableCollection::new(10.).unwrap();
-    /// # tables.add_node(tskit::NodeFlags::IS_SAMPLE, 10.0, -1, -1).unwrap();
+    /// # tables.add_node(tskit::NodeFlags::new_sample(), 10.0, -1, -1).unwrap();
     /// for time in tables.nodes_mut().time_slice_mut() {
     ///     *time = 55.0.into(); // change each node's time value
     /// }
@@ -787,7 +787,7 @@ impl NodeTable {
     /// ```
     /// # use tskit::prelude::*;
     /// # let mut tables = tskit::TableCollection::new(10.).unwrap();
-    /// # tables.add_node(tskit::NodeFlags::IS_SAMPLE, 10.0, -1, -1).unwrap();
+    /// # tables.add_node(tskit::NodeFlags::new_sample(), 10.0, -1, -1).unwrap();
     /// let flags = tables.nodes_mut().flags_slice_mut();
     /// for flag in flags {
     /// // Can do something...
@@ -798,7 +798,7 @@ impl NodeTable {
     /// ```
     /// # use tskit::prelude::*;
     /// # let mut tables = tskit::TableCollection::new(10.).unwrap();
-    /// # tables.add_node(tskit::NodeFlags::IS_SAMPLE, 10.0, -1, -1).unwrap();
+    /// # tables.add_node(tskit::NodeFlags::new_sample(), 10.0, -1, -1).unwrap();
     /// for flag in  tables.nodes_mut().flags_slice_mut() {
     /// # assert!(flag.is_sample());
     /// }
@@ -812,9 +812,9 @@ impl NodeTable {
     /// ```
     /// # use tskit::prelude::*;
     /// # let mut tables = tskit::TableCollection::new(10.).unwrap();
-    /// # tables.add_node(tskit::NodeFlags::IS_SAMPLE, 10.0, -1, -1).unwrap();
+    /// # tables.add_node(tskit::NodeFlags::new_sample(), 10.0, -1, -1).unwrap();
     /// for flag in tables.nodes_mut().flags_slice_mut() {
-    ///     flag.remove(tskit::NodeFlags::IS_SAMPLE);
+    ///     flag.remove(tskit::NodeFlags::new_sample());
     /// }
     /// assert!(!tables.nodes_mut().flags_slice_mut().iter().any(|f| f.is_sample()));
     /// assert!(tables.nodes().samples_as_vector().is_empty());
@@ -823,7 +823,7 @@ impl NodeTable {
     /// ```
     /// # use tskit::prelude::*;
     /// # let mut tables = tskit::TableCollection::new(10.).unwrap();
-    /// # tables.add_node(tskit::NodeFlags::IS_SAMPLE, 10.0, -1, -1).unwrap();
+    /// # tables.add_node(tskit::NodeFlags::new_sample(), 10.0, -1, -1).unwrap();
     /// let flags = tables.nodes_mut().flags_slice_mut().to_vec();
     /// # assert!(flags.iter().all(|f| f.is_sample()));
     /// ```
@@ -835,7 +835,7 @@ impl NodeTable {
     ///
     /// ```
     /// let mut nodes = tskit::OwningNodeTable::default();
-    /// assert!(nodes.add_row(tskit::NodeFlags::IS_SAMPLE, 10., -1, -1).is_ok());
+    /// assert!(nodes.add_row(tskit::NodeFlags::new_sample(), 10., -1, -1).is_ok());
     /// # assert_eq!(nodes.num_rows(), 1);
     /// let flags = nodes.flags_slice_mut();
     /// # assert_eq!(flags.len(), 1);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,6 @@
 //! Export commonly-use types and traits
 
 pub use crate::tsk_flags_t;
-pub use crate::TSK_NODE_IS_SAMPLE;
 pub use streaming_iterator::DoubleEndedStreamingIterator;
 pub use streaming_iterator::StreamingIterator;
 pub use {

--- a/src/table_views.rs
+++ b/src/table_views.rs
@@ -177,7 +177,7 @@ impl TableViews {
     }
 
     /// Obtain a vector containing the indexes ("ids")
-    /// of all nodes for which [`crate::TSK_NODE_IS_SAMPLE`]
+    /// of all nodes for which [`crate::NodeFlags::is_sample`]
     /// is `true`.
     ///
     /// The provided implementation dispatches to
@@ -206,11 +206,11 @@ impl TableViews {
     /// ```
     /// let mut tables = tskit::TableCollection::new(100.).unwrap();
     /// tables
-    ///     .add_node(tskit::TSK_NODE_IS_SAMPLE, 0.0, tskit::PopulationId::NULL,
+    ///     .add_node(tskit::NodeFlags::new_sample(), 0.0, tskit::PopulationId::NULL,
     ///     tskit::IndividualId::NULL)
     ///     .unwrap();
     /// tables
-    ///     .add_node(tskit::TSK_NODE_IS_SAMPLE, 1.0, tskit::PopulationId::NULL,
+    ///     .add_node(tskit::NodeFlags::new_sample(), 1.0, tskit::PopulationId::NULL,
     ///     tskit::IndividualId::NULL)
     ///     .unwrap();
     /// let samples = tables.create_node_id_vector(

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -54,7 +54,7 @@ pub fn make_small_table_collection() -> TableCollection {
         .unwrap();
     tables
         .add_node(
-            TSK_NODE_IS_SAMPLE,
+            NodeFlags::new_sample(),
             0.0,
             PopulationId::NULL,
             IndividualId::NULL,
@@ -62,7 +62,7 @@ pub fn make_small_table_collection() -> TableCollection {
         .unwrap();
     tables
         .add_node(
-            TSK_NODE_IS_SAMPLE,
+            NodeFlags::new_sample(),
             0.0,
             PopulationId::NULL,
             IndividualId::NULL,
@@ -104,7 +104,7 @@ pub fn make_small_table_collection_two_trees() -> TableCollection {
         .unwrap();
     tables
         .add_node(
-            TSK_NODE_IS_SAMPLE,
+            NodeFlags::new_sample(),
             0.0,
             PopulationId::NULL,
             IndividualId::NULL,
@@ -112,7 +112,7 @@ pub fn make_small_table_collection_two_trees() -> TableCollection {
         .unwrap();
     tables
         .add_node(
-            TSK_NODE_IS_SAMPLE,
+            NodeFlags::new_sample(),
             0.0,
             PopulationId::NULL,
             IndividualId::NULL,
@@ -120,7 +120,7 @@ pub fn make_small_table_collection_two_trees() -> TableCollection {
         .unwrap();
     tables
         .add_node(
-            TSK_NODE_IS_SAMPLE,
+            NodeFlags::new_sample(),
             0.0,
             PopulationId::NULL,
             IndividualId::NULL,
@@ -128,7 +128,7 @@ pub fn make_small_table_collection_two_trees() -> TableCollection {
         .unwrap();
     tables
         .add_node(
-            TSK_NODE_IS_SAMPLE,
+            NodeFlags::new_sample(),
             0.0,
             PopulationId::NULL,
             IndividualId::NULL,

--- a/tests/book_trees.rs
+++ b/tests/book_trees.rs
@@ -16,7 +16,7 @@ fn initialize_from_table_collection() {
         .unwrap();
     tables
         .add_node(
-            TSK_NODE_IS_SAMPLE,
+            tskit::NodeFlags::new_sample(),
             0.0,
             PopulationId::NULL,
             IndividualId::NULL,
@@ -24,7 +24,7 @@ fn initialize_from_table_collection() {
         .unwrap();
     tables
         .add_node(
-            TSK_NODE_IS_SAMPLE,
+            tskit::NodeFlags::new_sample(),
             0.0,
             PopulationId::NULL,
             IndividualId::NULL,
@@ -32,7 +32,7 @@ fn initialize_from_table_collection() {
         .unwrap();
     tables
         .add_node(
-            TSK_NODE_IS_SAMPLE,
+            tskit::NodeFlags::new_sample(),
             0.0,
             PopulationId::NULL,
             IndividualId::NULL,
@@ -40,7 +40,7 @@ fn initialize_from_table_collection() {
         .unwrap();
     tables
         .add_node(
-            TSK_NODE_IS_SAMPLE,
+            tskit::NodeFlags::new_sample(),
             0.0,
             PopulationId::NULL,
             IndividualId::NULL,

--- a/tests/test_tables.rs
+++ b/tests/test_tables.rs
@@ -146,9 +146,15 @@ mod test_adding_rows_without_metadata {
     #[test]
     fn test_adding_node() {
         {
-            let tables =
-                add_row_without_metadata!(nodes, add_node, tskit::TSK_NODE_IS_SAMPLE, 0.1, -1, -1); // flags, time, population,
-                                                                                                    // individual
+            let tables = add_row_without_metadata!(
+                nodes,
+                add_node,
+                tskit::NodeFlags::new_sample(),
+                0.1,
+                -1,
+                -1
+            ); // flags, time, population,
+               // individual
             assert!(tables
                 .nodes()
                 .flags_slice()


### PR DESCRIPTION
BREAKING CHANGE: Removed global constant from library and prelude.

Use of `NodeFlags` should be preferred.
