### PR TITLE
refactor: remove tsk_flags_t from lib.rs and prelude

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,6 @@ mod trees;
 pub mod types;
 mod util;
 
-// re-export types, too
-pub use bindings::tsk_flags_t;
-
 use bindings::tsk_id_t;
 use bindings::tsk_size_t;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,5 @@
 //! Export commonly-use types and traits
 
-pub use crate::tsk_flags_t;
 pub use streaming_iterator::DoubleEndedStreamingIterator;
 pub use streaming_iterator::StreamingIterator;
 pub use {


### PR DESCRIPTION
BREAKING CHANGE: removes a global pub type alias
