### PR TITLE
refactor: mark all pub enums non_exhaustive.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ use crate::TskReturnValue;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum TskitError {
     /// Returned when conversion attempts fail
     #[error("range error: {}", *.0)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -239,6 +239,7 @@ impl EncodedMetadata {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum MetadataError {
     /// Error related to types implementing
     /// [``MetadataRoundtrip``]

--- a/src/tree_interface.rs
+++ b/src/tree_interface.rs
@@ -571,6 +571,7 @@ impl TreeInterface {
 
 /// Specify the traversal order used by
 /// [`TreeInterface::traverse_nodes`].
+#[non_exhaustive]
 pub enum NodeTraversalOrder {
     ///Preorder traversal, starting at the root(s) of a [`TreeInterface`].
     ///For trees with multiple roots, start at the left root,


### PR DESCRIPTION
BREAKING CHANGE: some code will now need to match on _.
