### PR TITLE
Move slice creation back into sys::

### DIFF
--- a/src/_macros.rs
+++ b/src/_macros.rs
@@ -118,7 +118,8 @@ macro_rules! build_table_column_slice_getter {
     ($(#[$attr:meta])* => $column: ident, $name: ident, $cast: ty) => {
         $(#[$attr])*
         pub fn $name(&self) -> &[$cast] {
-            $crate::sys::generate_slice(self.as_ref().$column, self.num_rows())
+            // SAFETY: all array lengths are the number of rows in the table
+            unsafe{$crate::sys::generate_slice(self.as_ref().$column, self.num_rows())}
         }
     };
 }
@@ -127,7 +128,8 @@ macro_rules! build_table_column_slice_mut_getter {
     ($(#[$attr:meta])* => $column: ident, $name: ident, $cast: ty) => {
         $(#[$attr])*
         pub fn $name(&mut self) -> &mut [$cast] {
-            $crate::sys::generate_slice_mut(self.as_ref().$column, self.num_rows())
+            // SAFETY: all array lengths are the number of rows in the table
+            unsafe{$crate::sys::generate_slice_mut(self.as_ref().$column, self.num_rows())}
         }
     };
 }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -189,22 +189,28 @@ pub fn tsk_ragged_column_access<
         .map(|(p, n)| unsafe { std::slice::from_raw_parts(p.cast::<O>(), n) })
 }
 
-pub fn generate_slice<'a, L: Into<bindings::tsk_size_t>, I, O>(
+/// # SAFETY
+///
+/// * data must not be NULL
+/// * length must be a valid offset from data
+///   (ideally it comes from the tskit-c API)
+pub unsafe fn generate_slice<'a, L: Into<bindings::tsk_size_t>, I, O>(
     data: *const I,
     length: L,
 ) -> &'a [O] {
-    assert!(!data.is_null());
-    // SAFETY: pointer is not null, length comes from C API
-    unsafe { std::slice::from_raw_parts(data.cast::<O>(), length.into() as usize) }
+    std::slice::from_raw_parts(data.cast::<O>(), length.into() as usize)
 }
 
-pub fn generate_slice_mut<'a, L: Into<bindings::tsk_size_t>, I, O>(
+/// # SAFETY
+///
+/// * data must not be NULL
+/// * length must be a valid offset from data
+///   (ideally it comes from the tskit-c API)
+pub unsafe fn generate_slice_mut<'a, L: Into<bindings::tsk_size_t>, I, O>(
     data: *mut I,
     length: L,
 ) -> &'a mut [O] {
-    assert!(!data.is_null());
-    // SAFETY: pointer is not null, length comes from C API
-    unsafe { std::slice::from_raw_parts_mut(data.cast::<O>(), length.into() as usize) }
+    std::slice::from_raw_parts_mut(data.cast::<O>(), length.into() as usize)
 }
 
 pub fn get_tskit_error_message(code: i32) -> String {

--- a/src/trees/treeseq.rs
+++ b/src/trees/treeseq.rs
@@ -283,8 +283,10 @@ impl TreeSequence {
 
     /// Get the list of sample nodes as a slice.
     pub fn sample_nodes(&self) -> &[NodeId] {
-        let num_samples = unsafe { ll_bindings::tsk_treeseq_get_num_samples(self.as_ptr()) };
-        sys::generate_slice(self.as_ref().samples, num_samples)
+        unsafe {
+            let num_samples = ll_bindings::tsk_treeseq_get_num_samples(self.as_ref());
+            sys::generate_slice(self.as_ref().samples, num_samples)
+        }
     }
 
     /// Get the number of trees.


### PR DESCRIPTION
This PR fixes a safety issue:

* internal fns to generate slices from tables cannot possibly validate the "length" inputs
* thus, these fns should be marked unsafe.
* this PR does that and refactors internal types to build the arrays, thus providing a safe API for the primary public types to use
